### PR TITLE
Non-admins can't set disappearing message timers

### DIFF
--- a/run/test/specs/group_disappearing_messages_image.spec.ts
+++ b/run/test/specs/group_disappearing_messages_image.spec.ts
@@ -12,7 +12,7 @@ androidIt('Disappearing image message to group', 'low', disappearingImageMessage
 async function disappearingImageMessageGroup(platform: SupportedPlatformsType) {
   const { device1, device2, device3 } = await openAppThreeDevices(platform);
   const testMessage = 'Testing disappearing messages for images';
-  const testGroupName = 'Test group';
+  const testGroupName = 'Testing disappearing messages';
   const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
   const timerType = 'Disappear after send option';
   // Create user A and user B

--- a/run/test/specs/group_disappearing_messages_link.spec.ts
+++ b/run/test/specs/group_disappearing_messages_link.spec.ts
@@ -15,7 +15,7 @@ const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
 
 async function disappearingLinkMessageGroup(platform: SupportedPlatformsType) {
   const { device1, device2, device3 } = await openAppThreeDevices(platform);
-  const testGroupName = 'Test group';
+  const testGroupName = 'Testing disappearing messages';
   const testLink = `https://getsession.org/`;
   // Create user A and user B
   const [userA, userB, userC] = await Promise.all([

--- a/run/test/specs/group_disappearing_messages_members.spec.ts
+++ b/run/test/specs/group_disappearing_messages_members.spec.ts
@@ -29,7 +29,9 @@ async function membersCantSetDisappearingMessages(platform: SupportedPlatformsTy
   // On iOS, the Set button becomes visible after an admin clicks on a timer option
   // This is a 'fake' click on a disabled radial to rule out the false positive of the Set button becoming visible
   // On Android, this is not necessary because the button is always visible for admins
-  await device2.onIOS().clickOnElementAll(new DisappearingMessageRadial(device2, DISAPPEARING_TIMES.ONE_DAY));
+  await device2
+    .onIOS()
+    .clickOnElementAll(new DisappearingMessageRadial(device2, DISAPPEARING_TIMES.ONE_DAY));
   const setButton = await device2.doesElementExist({
     ...new SetDisappearMessagesButton(device2).build(),
     maxWait: 500,

--- a/run/test/specs/group_disappearing_messages_members.spec.ts
+++ b/run/test/specs/group_disappearing_messages_members.spec.ts
@@ -5,6 +5,7 @@ import { DISAPPEARING_TIMES, USERNAME } from '../../types/testing';
 import { createGroup } from './utils/create_group';
 import { ConversationSettings } from './locators/conversation';
 import {
+  DisappearingMessageRadial,
   DisappearingMessagesMenuOption,
   SetDisappearMessagesButton,
 } from './locators/disappearing_messages';
@@ -28,10 +29,7 @@ async function membersCantSetDisappearingMessages(platform: SupportedPlatformsTy
   // On iOS, the Set button becomes visible after an admin clicks on a timer option
   // This is a 'fake' click on a disabled radial to rule out the false positive of the Set button becoming visible
   // On Android, this is not necessary because the button is always visible for admins
-  await device2.onIOS().clickOnElementAll({
-    strategy: 'accessibility id',
-    selector: `${DISAPPEARING_TIMES.ONE_DAY} - Radio`, // I tried making this a locator class but I couldn't get it to work
-  });
+  await device2.onIOS().clickOnElementAll(new DisappearingMessageRadial(device2, DISAPPEARING_TIMES.ONE_DAY));
   const setButton = await device2.doesElementExist({
     ...new SetDisappearMessagesButton(device2).build(),
     maxWait: 500,

--- a/run/test/specs/group_disappearing_messages_members.spec.ts
+++ b/run/test/specs/group_disappearing_messages_members.spec.ts
@@ -13,7 +13,7 @@ bothPlatformsIt('Group member disappearing messages', 'medium', membersCantSetDi
 
 async function membersCantSetDisappearingMessages(platform: SupportedPlatformsType) {
   const { device1, device2, device3 } = await openAppThreeDevices(platform);
-  const testGroupName = 'Test group';
+  const testGroupName = 'Testing disappearing messages';
   // Create user A, B and C
   const [userA, userB, userC] = await Promise.all([
     newUser(device1, USERNAME.ALICE),
@@ -32,7 +32,10 @@ async function membersCantSetDisappearingMessages(platform: SupportedPlatformsTy
     strategy: 'accessibility id',
     selector: `${DISAPPEARING_TIMES.ONE_DAY} - Radio`, // I tried making this a locator class but I couldn't get it to work
   });
-  const setButton = await device2.doesElementExist(new SetDisappearMessagesButton(device2));
+  const setButton = await device2.doesElementExist({
+    ...new SetDisappearMessagesButton(device2).build(),
+    maxWait: 500,
+  });
   if (setButton) throw new Error('Disappearing Messages Set button should not be visible');
   await closeApp(device1, device2, device3);
 }

--- a/run/test/specs/group_disappearing_messages_members.spec.ts
+++ b/run/test/specs/group_disappearing_messages_members.spec.ts
@@ -1,0 +1,38 @@
+import { bothPlatformsIt } from '../../types/sessionIt';
+import { openAppThreeDevices, SupportedPlatformsType, closeApp } from './utils/open_app';
+import { newUser } from './utils/create_account';
+import { DISAPPEARING_TIMES, USERNAME } from '../../types/testing';
+import { createGroup } from './utils/create_group';
+import { ConversationSettings } from './locators/conversation';
+import {
+  DisappearingMessagesMenuOption,
+  SetDisappearMessagesButton,
+} from './locators/disappearing_messages';
+
+bothPlatformsIt('Group member disappearing messages', 'medium', membersCantSetDisappearingMessages);
+
+async function membersCantSetDisappearingMessages(platform: SupportedPlatformsType) {
+  const { device1, device2, device3 } = await openAppThreeDevices(platform);
+  const testGroupName = 'Test group';
+  // Create user A, B and C
+  const [userA, userB, userC] = await Promise.all([
+    newUser(device1, USERNAME.ALICE),
+    newUser(device2, USERNAME.BOB),
+    newUser(device3, USERNAME.CHARLIE),
+  ]);
+  // A creates group with B and C
+  await createGroup(platform, device1, userA, device2, userB, device3, userC, testGroupName);
+  // Member B navigates to DM settings
+  await device2.clickOnElementAll(new ConversationSettings(device2));
+  await device2.clickOnElementAll(new DisappearingMessagesMenuOption(device2));
+  // On iOS, the Set button becomes visible after an admin clicks on a timer option
+  // This is a 'fake' click on a disabled radial to rule out the false positive of the Set button becoming visible
+  // On Android, this is not necessary because the button is always visible for admins
+  await device2.onIOS().clickOnElementAll({
+    strategy: 'accessibility id',
+    selector: `${DISAPPEARING_TIMES.ONE_DAY} - Radio`, // I tried making this a locator class but I couldn't get it to work
+  });
+  const setButton = await device2.doesElementExist(new SetDisappearMessagesButton(device2));
+  if (setButton) throw new Error('Disappearing Messages Set button should not be visible');
+  await closeApp(device1, device2, device3);
+}

--- a/run/test/specs/group_disappearing_messages_video.spec.ts
+++ b/run/test/specs/group_disappearing_messages_video.spec.ts
@@ -13,7 +13,7 @@ const timerType = 'Disappear after send option';
 
 async function disappearingVideoMessageGroup(platform: SupportedPlatformsType) {
   const testMessage = 'Testing disappearing messages for videos';
-  const testGroupName = 'Test group';
+  const testGroupName = 'Testing disappearing messages';
   const { device1, device2, device3 } = await openAppThreeDevices(platform);
   // Create user A and user B
   const [userA, userB, userC] = await Promise.all([

--- a/run/test/specs/locators/disappearing_messages.ts
+++ b/run/test/specs/locators/disappearing_messages.ts
@@ -50,14 +50,10 @@ export class DisableDisappearingMessages extends LocatorsInterface {
 }
 export class SetDisappearMessagesButton extends LocatorsInterface {
   public build(): StrategyExtractionObj {
-    switch (this.platform) {
-      case 'android':
-      case 'ios':
-        return {
-          strategy: 'accessibility id',
-          selector: 'Set button',
-        } as const;
-    }
+    return {
+      strategy: 'accessibility id',
+      selector: 'Set button',
+    } as const;
   }
 }
 

--- a/run/test/specs/locators/disappearing_messages.ts
+++ b/run/test/specs/locators/disappearing_messages.ts
@@ -1,5 +1,7 @@
 import { LocatorsInterface } from '.';
 import { StrategyExtractionObj } from '../../../types/testing';
+import { DISAPPEARING_TIMES } from '../../../types/testing';
+import { DeviceWrapper } from '../../../types/DeviceWrapper';
 
 export class DisappearingMessagesMenuOption extends LocatorsInterface {
   public build(): StrategyExtractionObj {
@@ -80,5 +82,20 @@ export class FollowSettingsButton extends LocatorsInterface {
           selector: 'Follow setting',
         } as const;
     }
+  }
+}
+export class DisappearingMessageRadial extends LocatorsInterface {
+  private timer: DISAPPEARING_TIMES;
+
+// Receives a timer argument so that one locator can handle all DM durations
+constructor(device: DeviceWrapper, timer: DISAPPEARING_TIMES) {
+    super(device);
+    this.timer = timer;
+  }
+  public build(): StrategyExtractionObj {
+    return {
+      strategy: 'accessibility id',
+      selector: `${this.timer} - Radio`,
+    } as const;
   }
 }

--- a/run/test/specs/locators/disappearing_messages.ts
+++ b/run/test/specs/locators/disappearing_messages.ts
@@ -87,8 +87,8 @@ export class FollowSettingsButton extends LocatorsInterface {
 export class DisappearingMessageRadial extends LocatorsInterface {
   private timer: DISAPPEARING_TIMES;
 
-// Receives a timer argument so that one locator can handle all DM durations
-constructor(device: DeviceWrapper, timer: DISAPPEARING_TIMES) {
+  // Receives a timer argument so that one locator can handle all DM durations
+  constructor(device: DeviceWrapper, timer: DISAPPEARING_TIMES) {
     super(device);
     this.timer = timer;
   }

--- a/run/test/specs/locators/index.ts
+++ b/run/test/specs/locators/index.ts
@@ -505,22 +505,6 @@ export class DownloadMediaButton extends LocatorsInterface {
   }
 }
 
-export class SetDisappearMessagesButton extends LocatorsInterface {
-  public build(): StrategyExtractionObj {
-    switch (this.platform) {
-      case 'android':
-        return {
-          strategy: 'accessibility id',
-          selector: 'Set',
-        } as const;
-      case 'ios':
-        return {
-          strategy: 'accessibility id',
-          selector: 'Set button',
-        } as const;
-    }
-  }
-}
 export class ShareExtensionIcon extends LocatorsInterface {
   public build(): StrategyExtractionObj {
     switch (this.platform) {


### PR DESCRIPTION
Adds test to verify that a non-admin can't set a disappearing message timer in a group 