### PR TITLE
App Disguise tests 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,8 @@
 run/screenshots/android/landingpage_new_account.png filter=lfs diff=lfs merge=lfs -text
 run/screenshots/android/landingpage_restore_account.png filter=lfs diff=lfs merge=lfs -text
+run/screenshots/android/app_disguise.png filter=lfs diff=lfs merge=lfs -text
 run/screenshots/ios/landingpage_new_account.png filter=lfs diff=lfs merge=lfs -text
 run/screenshots/ios/landingpage_restore_account.png filter=lfs diff=lfs merge=lfs -text
+run/screenshots/ios/app_disguise.png filter=lfs diff=lfs merge=lfs -text
 .yarn/releases/yarn-4.1.1.cjs filter=lfs diff=lfs merge=lfs -text
 .yarn/releases/yarn-*.cjs filter=lfs diff=lfs merge=lfs -text

--- a/run/screenshots/android/app_disguise.png
+++ b/run/screenshots/android/app_disguise.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18ed347a459550771454d6038a4a4eb2d52792f0392ece8e8dace5c919251007
+size 127457

--- a/run/screenshots/ios/app_disguise.png
+++ b/run/screenshots/ios/app_disguise.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6987b366a695c5b9b39855e95230b0965928f4c7a6f7e9d090f2cf686191d8e0
+size 454344

--- a/run/test/specs/app_disguise_icons.spec.ts
+++ b/run/test/specs/app_disguise_icons.spec.ts
@@ -1,0 +1,28 @@
+import { bothPlatformsIt } from '../../types/sessionIt';
+import { SupportedPlatformsType, closeApp, openAppOnPlatformSingleDevice } from './utils/open_app';
+import { newUser } from './utils/create_account';
+import { USERNAME } from '../../types/testing';
+import { AppearanceMenuItem, SelectAppIcon, UserSettings } from './locators/settings';
+import { verifyElementScreenshot } from './utils/verify_screenshots';
+import { AppDisguisePageScreenshot } from './utils/screenshot_paths';
+import { sleepFor } from './utils';
+
+bothPlatformsIt({
+  title: 'App disguise icons',
+  risk: 'medium',
+  countOfDevicesNeeded: 1,
+  testCb: appDisguiseIcons,
+});
+
+async function appDisguiseIcons(platform: SupportedPlatformsType) {
+  const { device } = await openAppOnPlatformSingleDevice(platform);
+  await newUser(device, USERNAME.ALICE);
+  await device.clickOnElementAll(new UserSettings(device));
+  await device.clickOnElementAll(new AppearanceMenuItem(device));
+  await sleepFor(2000);
+  // Must scroll down to reveal the app disguise option
+  await device.scrollDown();
+  await device.clickOnElementAll(new SelectAppIcon(device));
+  await verifyElementScreenshot(device, new AppDisguisePageScreenshot(device));
+  await closeApp(device);
+}

--- a/run/test/specs/app_disguise_set.spec.ts
+++ b/run/test/specs/app_disguise_set.spec.ts
@@ -1,0 +1,51 @@
+import { androidIt } from '../../types/sessionIt';
+import { SupportedPlatformsType, openAppOnPlatformSingleDevice } from './utils/open_app';
+import { newUser } from './utils/create_account';
+import { USERNAME } from '../../types/testing';
+import {
+  AppDisguiseMeetingIcon,
+  AppearanceMenuItem,
+  CloseAppButton,
+  SelectAppIcon,
+  UserSettings,
+} from './locators/settings';
+import { DisguisedApp } from './locators/external';
+import { sleepFor } from './utils';
+import { runScriptAndLog } from './utils/utilities';
+import { getAdbFullPath } from './utils/binaries';
+
+// iOS implementation blocked by SES-3809
+androidIt({
+  title: 'App disguise set icon',
+  risk: 'medium',
+  countOfDevicesNeeded: 1,
+  testCb: appDisguiseSetIcon,
+});
+
+async function appDisguiseSetIcon(platform: SupportedPlatformsType) {
+  const { device } = await openAppOnPlatformSingleDevice(platform);
+  try {
+    await newUser(device, USERNAME.ALICE);
+    await device.clickOnElementAll(new UserSettings(device));
+    await device.clickOnElementAll(new AppearanceMenuItem(device));
+    await sleepFor(2000);
+    // Must scroll down to reveal the app disguise option
+    await device.scrollDown();
+    await device.clickOnElementAll(new SelectAppIcon(device));
+    await device.clickOnElementAll(new AppDisguiseMeetingIcon(device));
+    // TODO check modal strings once locales.ts has been updated
+    await device.clickOnElementAll(new CloseAppButton(device));
+    await sleepFor(2000);
+    // Open app library and check for disguised app
+    await runScriptAndLog(
+      `${getAdbFullPath()} -s ${device.udid} shell input swipe 500 1700 500 500`
+    );
+    await device.waitForTextElementToBePresent(new DisguisedApp(device));
+  } finally {
+    // The disguised app must be uninstalled otherwise every following test will fail
+    await runScriptAndLog(
+      `${getAdbFullPath()} -s ${device.udid} uninstall network.loki.messenger`,
+      true
+    );
+  }
+}

--- a/run/test/specs/locators/external.ts
+++ b/run/test/specs/locators/external.ts
@@ -8,3 +8,12 @@ export class PhotoLibrary extends LocatorsInterface {
     } as const;
   }
 }
+
+export class DisguisedApp extends LocatorsInterface {
+  public build() {
+    return {
+      strategy: 'accessibility id',
+      selector: 'MeetingSE',
+    } as const;
+  }
+}

--- a/run/test/specs/locators/settings.ts
+++ b/run/test/specs/locators/settings.ts
@@ -104,3 +104,82 @@ export class BlockedContacts extends LocatorsInterface {
     }
   }
 }
+
+export class AppearanceMenuItem extends LocatorsInterface {
+  public build() {
+    switch (this.platform) {
+      case 'android':
+        return {
+          strategy: 'accessibility id',
+          selector: 'Appearance',
+        } as const;
+      case 'ios':
+        return {
+          strategy: 'accessibility id',
+          selector: 'Appearance',
+        } as const;
+    }
+  }
+}
+
+export class SelectAppIcon extends LocatorsInterface {
+  public build() {
+    switch (this.platform) {
+      case 'android':
+        return {
+          strategy: 'id',
+          selector: 'network.loki.messenger:id/system_settings_app_icon',
+        } as const;
+      case 'ios':
+        return {
+          strategy: 'accessibility id',
+          selector: 'Select alternate app icon',
+        } as const;
+    }
+  }
+}
+export class AppDisguisePage extends LocatorsInterface {
+  public build() {
+    switch (this.platform) {
+      case 'android':
+        return {
+          strategy: 'class name',
+          selector: 'android.widget.ScrollView',
+        } as const;
+      case 'ios':
+        return {
+          strategy: 'class name',
+          selector: 'XCUIElementTypeTable',
+        } as const;
+    }
+  }
+}
+export class AppDisguiseMeetingIcon extends LocatorsInterface {
+  public build() {
+    switch (this.platform) {
+      case 'android':
+        return {
+          strategy: 'id',
+          selector: 'MeetingSE option',
+        } as const;
+      case 'ios':
+        // NOTE see SES-3809
+        throw new Error('No locators implemented for iOS');
+    }
+  }
+}
+
+export class CloseAppButton extends LocatorsInterface {
+  public build() {
+    switch (this.platform) {
+      case 'android':
+        return {
+          strategy: 'class name',
+          selector: 'android.widget.TextView',
+          text: 'Close App',
+        } as const;
+      case 'ios':
+        throw new Error('Modal not implemented for iOS');
+    }
+  }
+}

--- a/run/test/specs/utils/screenshot_paths.ts
+++ b/run/test/specs/utils/screenshot_paths.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { EmptyLandingPage } from '../locators/home';
+import { AppDisguisePage } from '../locators/settings';
 
 // Extends locator classes with baseline screenshot paths for visual regression testing
 // If a locator appears in multiple states, a state argument must be provided to screenshotFileName()
@@ -8,5 +9,11 @@ export class EmptyLandingPageScreenshot extends EmptyLandingPage {
   // The landing page has two different states depending on the onboarding flow taken
   public screenshotFileName(state: 'new_account' | 'restore_account'): string {
     return path.join('run', 'screenshots', this.platform, `landingpage_${state}.png`);
+  }
+}
+
+export class AppDisguisePageScreenshot extends AppDisguisePage {
+  public screenshotFileName(): string {
+    return path.join('run', 'screenshots', this.platform, 'app_disguise.png');
   }
 }

--- a/run/types/testing.ts
+++ b/run/types/testing.ts
@@ -350,7 +350,10 @@ export type AccessibilityId =
   | 'Legacy Groups Recreate Button'
   | 'Confirm leave'
   | 'Photo, 25 March, 11:09 am'
-  | 'Albums';
+  | 'Albums'
+  | 'Appearance'
+  | 'Select alternate app icon'
+  | 'MeetingSE';
 
 export type Id =
   | 'Modal heading'
@@ -417,7 +420,8 @@ export type Id =
   | 'Remove'
   | 'Contact status'
   | 'Image button'
-  | 'android.widget.TextView';
+  | 'network.loki.messenger:id/system_settings_app_icon'
+  | 'MeetingSE option';
 
 export type TestRisk = 'high' | 'medium' | 'low';
 


### PR DESCRIPTION
- Adds tests for app disguise feature
    - Visual check - do the icons match
    - Set an alternate app icon (currently Android only, test tags are pending for iOS) 