### PR TITLE
Android 1.24.1 changes

### DIFF
--- a/.github/workflows/android-regression.yml
+++ b/.github/workflows/android-regression.yml
@@ -5,10 +5,9 @@ on:
   workflow_dispatch:
     inputs:
       APK_URL:
-        description: 'url to test'
+        description: 'apk url to test (.tar.xz)'
         required: true
         type: string
-        default: https://oxen.rocks/session-foundation/session-android/release/1.22.1/session-android-20250406T231441Z-a9bfe783a-universal.tar.xz
 
       RISK:
         description: 'risks to target'

--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -5,10 +5,9 @@ on:
   workflow_dispatch:
     inputs:
       APK_URL:
-        description: 'ipa url to test'
+        description: 'ipa url to test (.tar.xz)'
         required: true
         type: string
-        default: https://oxen.rocks/session-foundation/session-ios/dev/session-ios-20250408T201952Z-233314350-sim.tar.xz
 
       RISK:
         description: 'risks to target'

--- a/run/test/specs/linked_device_block_user.spec.ts
+++ b/run/test/specs/linked_device_block_user.spec.ts
@@ -63,6 +63,8 @@ async function blockUserInConversationOptions(platform: SupportedPlatformsType) 
     alice1.clickOnElementAll(new UserSettings(alice1)),
     alice2.clickOnElementAll(new UserSettings(alice2)),
   ]);
+  // 'Conversations' might be hidden beyond the Settings view, gotta scroll down to find it
+  await Promise.all([alice1.scrollDown(), alice2.scrollDown()]);
   await Promise.all([
     alice1.clickOnElementAll({ strategy: 'accessibility id', selector: 'Conversations' }),
     alice2.clickOnElementAll({ strategy: 'accessibility id', selector: 'Conversations' }),

--- a/run/test/specs/message_requests_block.spec.ts
+++ b/run/test/specs/message_requests_block.spec.ts
@@ -76,6 +76,8 @@ async function blockedRequest(platform: SupportedPlatformsType) {
     device2.clickOnElementAll(new UserSettings(device2)),
     device3.clickOnElementAll(new UserSettings(device3)),
   ]);
+  // 'Conversations' might be hidden beyond the Settings view, gotta scroll down to find it
+  await Promise.all([device2.scrollDown(), device3.scrollDown()]);
   await Promise.all([
     device2.clickOnElementAll({ strategy: 'accessibility id', selector: 'Conversations' }),
     device3.clickOnElementAll({ strategy: 'accessibility id', selector: 'Conversations' }),

--- a/run/test/specs/user_actions_block_conversation_list.spec.ts
+++ b/run/test/specs/user_actions_block_conversation_list.spec.ts
@@ -44,6 +44,8 @@ async function blockUserInConversationList(platform: SupportedPlatformsType) {
   });
   await alice1.navigateBack();
   await alice1.clickOnElementAll(new UserSettings(alice1));
+  // 'Conversations' might be hidden beyond the Settings view, gotta scroll down to find it
+  await alice1.scrollDown();
   await alice1.clickOnElementAll({ strategy: 'accessibility id', selector: 'Conversations' });
   await alice1.clickOnElementAll(new BlockedContactsSettings(alice1));
   await alice1.waitForTextElementToBePresent({

--- a/run/test/specs/user_actions_block_conversation_options.spec.ts
+++ b/run/test/specs/user_actions_block_conversation_options.spec.ts
@@ -58,6 +58,8 @@ async function blockUserInConversationOptions(platform: SupportedPlatformsType) 
   // Check settings for blocked user
   await alice1.navigateBack();
   await alice1.clickOnElementAll(new UserSettings(alice1));
+  // 'Conversations' might be hidden beyond the Settings view, gotta scroll down to find it
+  await alice1.scrollDown();
   await alice1.clickOnElementAll({ strategy: 'accessibility id', selector: 'Conversations' });
   await alice1.clickOnElementAll(new BlockedContactsSettings(alice1));
   // Accessibility ID for Blocked Contact not present on iOS

--- a/run/test/specs/voice_calls.spec.ts
+++ b/run/test/specs/voice_calls.spec.ts
@@ -5,6 +5,7 @@ import { open_Alice1_bob1_notfriends } from './state_builder';
 import { sleepFor } from './utils/index';
 import { SupportedPlatformsType, closeApp } from './utils/open_app';
 
+// skipping tests because they are unreliable on virtual devices, see QA-478
 bothPlatformsItSeparate({
   title: 'Voice calls',
   risk: 'high',
@@ -15,6 +16,7 @@ bothPlatformsItSeparate({
   },
   android: {
     testCb: voiceCallAndroid,
+    shouldSkip: true,
   },
 });
 


### PR DESCRIPTION
- Need to scroll down to see `Conversations` in the Settings menu now 
- Skipping Voice calls test because unreliable on emulators
- Remove default APK_URL from workflow because I kept running tests on old APK