### PR TITLE
fix: Allure reports serve LFS URLs

### DIFF
--- a/.github/workflows/prune-attachments.yml
+++ b/.github/workflows/prune-attachments.yml
@@ -1,7 +1,7 @@
 name: Prune Old Allure Attachments
 on:
   schedule:
-    - cron: '0 16 * * 0'  # Weekly, 16:00 UTC Sunday
+    - cron: '0 16 * * 0' # Weekly, 16:00 UTC Sunday
 
 jobs:
   prune:
@@ -11,17 +11,17 @@ jobs:
         with:
           ref: gh-pages
           lfs: true
-        env: 
+        env:
           GIT_LFS_SKIP_SMUDGE: 1 # Don't actually download LFS content
-      
+
       - name: Prune Allure attachments older than 14 days
         run: |
           echo "## Pruning Report" >> $GITHUB_STEP_SUMMARY
           COUNT=$(find . -type f -path "*/data/attachments/*" \( -name "*.png" -o -name "*.txt" -o -name "*.imagediff" \) -mtime +14 | wc -l)
           echo "Deleting $COUNT files older than 14 days" >> $GITHUB_STEP_SUMMARY
-          
+
           find . -type f -path "*/data/attachments/*" \( -name "*.png" -o -name "*.txt" -o -name "*.imagediff" \) -mtime +14 -delete
-          
+
       - name: Commit changes
         run: |
           git config user.name "github-actions"

--- a/.github/workflows/prune-attachments.yml
+++ b/.github/workflows/prune-attachments.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   prune:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/prune-attachments.yml
+++ b/.github/workflows/prune-attachments.yml
@@ -11,14 +11,16 @@ jobs:
         with:
           ref: gh-pages
           lfs: true
+        env: 
+          GIT_LFS_SKIP_SMUDGE: 1 # Don't actually download LFS content
       
       - name: Prune Allure attachments older than 14 days
         run: |
           echo "## Pruning Report" >> $GITHUB_STEP_SUMMARY
-          COUNT=$(find . -path "*/data/attachments/*" \( -name "*.png" -o -name "*.txt" -o -name "*.imagediff" \) -mtime +14 | wc -l)
+          COUNT=$(find . -type f -path "*/data/attachments/*" \( -name "*.png" -o -name "*.txt" -o -name "*.imagediff" \) -mtime +14 | wc -l)
           echo "Deleting $COUNT files older than 14 days" >> $GITHUB_STEP_SUMMARY
           
-          find . -path "*/data/attachments/*" \( -name "*.png" -o -name "*.txt" -o -name "*.imagediff" \) -mtime +14 -delete
+          find . -type f -path "*/data/attachments/*" \( -name "*.png" -o -name "*.txt" -o -name "*.imagediff" \) -mtime +14 -delete
           
       - name: Commit changes
         run: |
@@ -27,3 +29,9 @@ jobs:
           git add -A
           git commit -m "Prune attachments older than 14 days" || echo "Nothing to prune"
           git push
+
+      - name: Prune LFS objects
+        run: |
+          echo "## Pruning LFS objects" >> $GITHUB_STEP_SUMMARY
+          git lfs prune --verify-remote
+          echo "LFS prune complete" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/prune-attachments.yml
+++ b/.github/workflows/prune-attachments.yml
@@ -1,0 +1,29 @@
+name: Prune Old Allure Attachments
+on:
+  schedule:
+    - cron: '0 16 * * 0'  # Weekly, 16:00 UTC Sunday
+
+jobs:
+  prune:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          lfs: true
+      
+      - name: Prune Allure attachments older than 14 days
+        run: |
+          echo "## Pruning Report" >> $GITHUB_STEP_SUMMARY
+          COUNT=$(find . -path "*/data/attachments/*" \( -name "*.png" -o -name "*.txt" -o -name "*.imagediff" \) -mtime +14 | wc -l)
+          echo "Deleting $COUNT files older than 14 days" >> $GITHUB_STEP_SUMMARY
+          
+          find . -path "*/data/attachments/*" \( -name "*.png" -o -name "*.txt" -o -name "*.imagediff" \) -mtime +14 -delete
+          
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          git add -A
+          git commit -m "Prune attachments older than 14 days" || echo "Nothing to prune"
+          git push

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,3 @@
+[lfs]
+    # Skip downloading test report attachments from gh-pages
+    fetchexclude = ios/**/data/attachments/**,android/**/data/attachments/**

--- a/github/actions/fetch-allure-history/action.yml
+++ b/github/actions/fetch-allure-history/action.yml
@@ -19,7 +19,7 @@ runs:
         rm -rf "$CLONE_DIR"
 
         echo "Cloning gh-pages branch"
-        git clone --depth 1 --branch gh-pages "$GH_REPO" "$CLONE_DIR"
+        GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 --branch gh-pages "$GH_REPO" "$CLONE_DIR"
 
         echo "Searching for latest report for $PLATFORM"
         LATEST_HISTORY=$(find "$REPORTS_DIR" -type d -name "run-*-${PLATFORM}-*" | sort | tail -n1)

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-perfectionist": "^4.15.0",
     "fs-extra": "^11.3.0",
     "gh-pages": "^6.3.0",
+    "glob": "^11.0.3",
     "globals": "^15.12.0",
     "lodash": "^4.17.21",
     "looks-same": "^9.0.1",

--- a/run/test/specs/utils/allure/allureHelpers.ts
+++ b/run/test/specs/utils/allure/allureHelpers.ts
@@ -128,15 +128,15 @@ export async function writeMetadataJson(ctx: ReportContext) {
  */
 export async function patchFilesForLFSCDN(ctx: ReportContext) {
   console.log('Patching attachment URLs for LFS CDN...');
-  
+
   const cdnBase = `https://media.githubusercontent.com/media/session-foundation/session-appium/gh-pages/${ctx.platform}/${ctx.reportFolder}`;
-  
+
   // Get all files that need patching
   const filesToPatch = [
     path.join(allureCurrentReportDir, 'app.js'),
-    ...(await glob(`${allureCurrentReportDir}/plugin/*/index.js`))
+    ...(await glob(`${allureCurrentReportDir}/plugin/*/index.js`)),
   ];
-  
+
   // Patch them all
   for (const file of filesToPatch) {
     if (await fs.pathExists(file)) {
@@ -147,7 +147,7 @@ export async function patchFilesForLFSCDN(ctx: ReportContext) {
       await fs.writeFile(file, content);
     }
   }
-  
+
   console.log(`Patched ${filesToPatch.length} files for LFS CDN`);
 }
 

--- a/run/test/specs/utils/allure/allureHelpers.ts
+++ b/run/test/specs/utils/allure/allureHelpers.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process';
 import fs from 'fs-extra';
+import { glob } from 'glob';
 import path from 'path';
 
 import {
@@ -118,6 +119,36 @@ export async function writeMetadataJson(ctx: ReportContext) {
     JSON.stringify(metadata, null, 2)
   );
   console.log('Created metadata.json');
+}
+
+/**
+ * Patches Allure files to use GitHub's LFS CDN URLs instead of relative paths.
+ * GitHub Pages serves LFS pointer files, not actual content, so we rewrite
+ * attachment URLs to use media.githubusercontent.com which serves the real files.
+ */
+export async function patchFilesForLFSCDN(ctx: ReportContext) {
+  console.log('Patching attachment URLs for LFS CDN...');
+  
+  const cdnBase = `https://media.githubusercontent.com/media/session-foundation/session-appium/gh-pages/${ctx.platform}/${ctx.reportFolder}`;
+  
+  // Get all files that need patching
+  const filesToPatch = [
+    path.join(allureCurrentReportDir, 'app.js'),
+    ...(await glob(`${allureCurrentReportDir}/plugin/*/index.js`))
+  ];
+  
+  // Patch them all
+  for (const file of filesToPatch) {
+    if (await fs.pathExists(file)) {
+      let content = await fs.readFile(file, 'utf-8');
+      content = content
+        .replace(/"data\/attachments\//g, `"${cdnBase}/data/attachments/`)
+        .replace(/'data\/attachments\//g, `'${cdnBase}/data/attachments/`);
+      await fs.writeFile(file, content);
+    }
+  }
+  
+  console.log(`Patched ${filesToPatch.length} files for LFS CDN`);
 }
 
 // Custom css injection for neat diffing and media display

--- a/run/test/specs/utils/allure/publishReport.ts
+++ b/run/test/specs/utils/allure/publishReport.ts
@@ -3,7 +3,7 @@ import ghpages from 'gh-pages';
 import path from 'path';
 
 import { allureCurrentReportDir } from '../../../../constants/allure';
-import { getReportContextFromEnv, patchStylesCss, writeMetadataJson } from './allureHelpers';
+import { getReportContextFromEnv, patchFilesForLFSCDN, patchStylesCss, writeMetadataJson } from './allureHelpers';
 
 // Bail out early if not on CI
 if (process.env.CI !== '1' || process.env.ALLURE_ENABLED === 'false') {
@@ -46,7 +46,9 @@ async function publishReport() {
   const publishedReportName = ctx.reportFolder;
   const newReportDir = path.join(ctx.platform, publishedReportName);
 
+  // Allue manipulation
   await patchStylesCss();
+  await patchFilesForLFSCDN(ctx); 
 
   // Copy the current report to newReportDir for publishing
   // By doing so, the gh-pages branch hosts /android and /ios subpages with the respective reports

--- a/run/test/specs/utils/allure/publishReport.ts
+++ b/run/test/specs/utils/allure/publishReport.ts
@@ -3,7 +3,12 @@ import ghpages from 'gh-pages';
 import path from 'path';
 
 import { allureCurrentReportDir } from '../../../../constants/allure';
-import { getReportContextFromEnv, patchFilesForLFSCDN, patchStylesCss, writeMetadataJson } from './allureHelpers';
+import {
+  getReportContextFromEnv,
+  patchFilesForLFSCDN,
+  patchStylesCss,
+  writeMetadataJson,
+} from './allureHelpers';
 
 // Bail out early if not on CI
 if (process.env.CI !== '1' || process.env.ALLURE_ENABLED === 'false') {
@@ -48,7 +53,7 @@ async function publishReport() {
 
   // Allue manipulation
   await patchStylesCss();
-  await patchFilesForLFSCDN(ctx); 
+  await patchFilesForLFSCDN(ctx);
 
   // Copy the current report to newReportDir for publishing
   // By doing so, the gh-pages branch hosts /android and /ios subpages with the respective reports

--- a/yarn.lock
+++ b/yarn.lock
@@ -597,6 +597,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/balanced-match@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@isaacs/balanced-match@npm:4.0.1"
+  checksum: 10c0/7da011805b259ec5c955f01cee903da72ad97c5e6f01ca96197267d3f33103d5b2f8a1af192140f3aa64526c593c8d098ae366c2b11f7f17645d12387c2fd420
+  languageName: node
+  linkType: hard
+
+"@isaacs/brace-expansion@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@isaacs/brace-expansion@npm:5.0.0"
+  dependencies:
+    "@isaacs/balanced-match": "npm:^4.0.1"
+  checksum: 10c0/b4d4812f4be53afc2c5b6c545001ff7a4659af68d4484804e9d514e183d20269bb81def8682c01a22b17c4d6aed14292c8494f7d2ac664e547101c1a905aa977
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -3850,7 +3866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"foreground-child@npm:^3.1.0":
+"foreground-child@npm:^3.1.0, foreground-child@npm:^3.3.1":
   version: 3.3.1
   resolution: "foreground-child@npm:3.3.1"
   dependencies:
@@ -4158,6 +4174,22 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 10c0/19a9759ea77b8e3ca0a43c2f07ecddc2ad46216b786bb8f993c445aee80d345925a21e5280c7b7c6c59e860a0154b84e4b2b60321fea92cd3c56b4a7489f160e
+  languageName: node
+  linkType: hard
+
+"glob@npm:^11.0.3":
+  version: 11.0.3
+  resolution: "glob@npm:11.0.3"
+  dependencies:
+    foreground-child: "npm:^3.3.1"
+    jackspeak: "npm:^4.1.1"
+    minimatch: "npm:^10.0.3"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^2.0.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/7d24457549ec2903920dfa3d8e76850e7c02aa709122f0164b240c712f5455c0b457e6f2a1eee39344c6148e39895be8094ae8cfef7ccc3296ed30bce250c661
   languageName: node
   linkType: hard
 
@@ -4691,6 +4723,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "jackspeak@npm:4.1.1"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+  checksum: 10c0/84ec4f8e21d6514db24737d9caf65361511f75e5e424980eebca4199f400874f45e562ac20fa8aeb1dd20ca2f3f81f0788b6e9c3e64d216a5794fd6f30e0e042
+  languageName: node
+  linkType: hard
+
 "js-graph-algorithms@npm:1.0.18":
   version: 1.0.18
   resolution: "js-graph-algorithms@npm:1.0.18"
@@ -5144,6 +5185,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.0":
+  version: 11.1.0
+  resolution: "lru-cache@npm:11.1.0"
+  checksum: 10c0/85c312f7113f65fae6a62de7985348649937eb34fb3d212811acbf6704dc322a421788aca253b62838f1f07049a84cc513d88f494e373d3756514ad263670a64
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^7.14.1":
   version: 7.18.3
   resolution: "lru-cache@npm:7.18.3"
@@ -5313,6 +5361,15 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^1.1.7"
   checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.0.3":
+  version: 10.0.3
+  resolution: "minimatch@npm:10.0.3"
+  dependencies:
+    "@isaacs/brace-expansion": "npm:^5.0.0"
+  checksum: 10c0/e43e4a905c5d70ac4cec8530ceaeccb9c544b1ba8ac45238e2a78121a01c17ff0c373346472d221872563204eabe929ad02669bb575cb1f0cc30facab369f70f
   languageName: node
   linkType: hard
 
@@ -5995,6 +6052,16 @@ __metadata:
     lru-cache: "npm:^10.2.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10c0/32a13711a2a505616ae1cc1b5076801e453e7aae6ac40ab55b388bb91b9d0547a52f5aaceff710ea400205f18691120d4431e520afbe4266b836fadede15872d
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/3da4adedaa8e7ef8d6dc4f35a0ff8f05a9b4d8365f2b28047752b62d4c1ad73eec21e37b1579ef2d075920157856a3b52ae8309c480a6f1a8bbe06ff8e52b33c
   languageName: node
   linkType: hard
 
@@ -6738,6 +6805,7 @@ __metadata:
     eslint-plugin-perfectionist: "npm:^4.15.0"
     fs-extra: "npm:^11.3.0"
     gh-pages: "npm:^6.3.0"
+    glob: "npm:^11.0.3"
     globals: "npm:^15.12.0"
     lodash: "npm:^4.17.21"
     looks-same: "npm:^9.0.1"


### PR DESCRIPTION
- all attachments (txt, png, imagediff) are now stored in LFS
    - this change was done directly on the `gh-pages` branch 
- LFS attachments are not served in `gh-pages` directly so we must rewrite the `allure` URLs to point to the LFS CDN `https://media.githubusercontent.com/media/session-foundation/session-appium/...` 
    - this change has been retroactively applied to all existing reports  