### PR TITLE
fix: set fetch-depth 0

### DIFF
--- a/.github/workflows/prune-attachments.yml
+++ b/.github/workflows/prune-attachments.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           ref: gh-pages
           lfs: true
+          fetch-depth: 0 # Get full history to check file ages
         env:
           GIT_LFS_SKIP_SMUDGE: 1 # Don't actually download LFS content
 


### PR DESCRIPTION
by default the checkout action only does a shallow clone meaning older attachments were never checked out 
successful dry run at: https://github.com/session-foundation/session-appium/actions/runs/17195821255