### PR TITLE
Add explicit pages deployment action

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,40 @@
+# Recent changes to GitHub Actions requires a separate deployment action to be ran 
+# in order to publish to GitHub Pages. This action listens to pushes on the gh-pages 
+# branch from the regression test workflows and deploys the reports. 
+name: Deploy Allure Reports to GitHub Pages
+
+on:
+  push:
+    branches: ["gh-pages"]
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+          
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/github/actions/generate-publish-test-report/action.yml
+++ b/github/actions/generate-publish-test-report/action.yml
@@ -53,5 +53,6 @@ runs:
         echo "### Regression Test Report" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "[Click here to view the report](${report_url})" >> $GITHUB_STEP_SUMMARY
+        echo "⏳ **Note:** GitHub Pages deployment will run automatically after this workflow completes." >> $GITHUB_STEP_SUMMARY
       env:
         report_url: ${{ steps.publish.outputs.report_url }}

--- a/run/test/specs/utils/allure/publishReport.ts
+++ b/run/test/specs/utils/allure/publishReport.ts
@@ -18,6 +18,13 @@ if (process.env.CI !== '1' || process.env.ALLURE_ENABLED === 'false') {
 
 // Publishes the report directory to the gh-pages branch of the repo
 function publishToGhPages(dir: string, dest: string, repo: string, message: string): Promise<void> {
+  // Ensure .nojekyll file exists to skip Jekyll processing
+  const nojekyllPath = path.join(dir, '.nojekyll');
+  if (!fs.existsSync(nojekyllPath)) {
+    fs.writeFileSync(nojekyllPath, '');
+    console.log('Created .nojekyll file');
+  }
+  
   return new Promise((resolve, reject) => {
     void ghpages.publish(
       dir,


### PR DESCRIPTION
GitHub Actions stopped working on push to `gh-pages` so we need an explicit deployment workflow that listens to changes on the `gh-pages` branch