### PR TITLE
Parallel local test runs and configurable service network

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,3 +11,12 @@ PLAYWRIGHT_RETRIES_COUNT=0
 PLAYWRIGHT_REPEAT_COUNT=0
 PLAYWRIGHT_WORKERS_COUNT=1
 UPDATE_BASELINES='false' # true auto-saves missing baseline screenshots
+
+# Service network (mainnet default). Set to devnet/testnet to avoid full mainnet
+# onion-routing latency (the dominant cost of the slowest multi-device tests).
+# devnet requires all four DEVNET_* values below AND a reachable devnet (see CLAUDE.md).
+# NETWORK_TARGET=devnet
+# DEVNET_PUBKEY=<64-char hex seed-node pubkey>
+# DEVNET_IP=10.0.0.1
+# DEVNET_HTTP_PORT=1280
+# DEVNET_OMQ_PORT=<seed-node OMQ/QUIC port>

--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -4,6 +4,16 @@ run-name: '${{ inputs.RISK }} regressions on ${{ github.head_ref || github.ref }
 on:
   workflow_dispatch:
     inputs:
+      NETWORK_TARGET:
+        description: 'network target to run the tests on'
+        required: true
+        type: choice
+        options:
+          - 'devnet'
+          - 'testnet'
+          - 'mainnet'
+        default: 'mainnet'
+
       APK_URL:
         description: 'ipa url to test (.tar.xz)'
         required: true
@@ -84,7 +94,19 @@ jobs:
       APPIUM_ADB_FULL_PATH: '<just_not_empty>'
       ANDROID_SDK_ROOT: '<just_not_empty>'
       PLAYWRIGHT_RETRIES_COUNT: ${{ github.event.inputs.PLAYWRIGHT_RETRIES_COUNT }}
-      NETWORK_TARGET: 'mainnet' # iOS only supports mainnet for now
+      # iOS selects the network at launch (one build, no AQA/regular variants like Android):
+      # NETWORK_TARGET drives capabilities_ios.ts + getNetworkTarget (and is used for the report).
+      # For devnet the app also needs the seed-node connection details below; they are only read
+      # when devnet is selected, so they are harmless on mainnet/testnet runs. Store them as
+      # repo-level Actions *variables* (the pubkey is public; the IP/ports are internal), e.g.
+      # Settings > Secrets and variables > Actions. DEVNET_IP must be the address the runner can
+      # reach (the same devnet as Android's sesh-net.local:1280); the seeder derives its seed URL
+      # from DEVNET_IP:DEVNET_HTTP_PORT.
+      NETWORK_TARGET: ${{ github.event.inputs.NETWORK_TARGET }}
+      DEVNET_PUBKEY: ${{ vars.DEVNET_PUBKEY }}
+      DEVNET_IP: ${{ vars.DEVNET_IP }}
+      DEVNET_HTTP_PORT: ${{ vars.DEVNET_HTTP_PORT }}
+      DEVNET_OMQ_PORT: ${{ vars.DEVNET_OMQ_PORT }}
       _TESTING: 1 # Always hide webdriver logs (@appium/support/ flag)
       PRINT_FAILED_TEST_LOGS: ${{ github.event.inputs.LOG_LEVEL != 'minimal' && '1' || '0' }} # Show stdout/stderr if test fails (@session-foundation/playwright-reporter/ flag)
       PRINT_ONGOING_TEST_LOGS: ${{ github.event.inputs.LOG_LEVEL == 'verbose' && '1' || '0' }} # Show everything as it happens (@session-foundation/playwright-reporter/ flag)
@@ -104,6 +126,28 @@ jobs:
         with:
           PLATFORM: ${{ env.PLATFORM }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Fail fast (before the app download / sim setup) if devnet was requested but its
+      # connection details are missing or the seed node is unreachable. Mirrors the Android
+      # workflow's probe. On mainnet this step is skipped entirely.
+      - name: Probe devnet reachability
+        if: ${{ github.event.inputs.NETWORK_TARGET == 'devnet' }}
+        shell: bash
+        run: |
+          if [ -z "$DEVNET_PUBKEY" ] || [ -z "$DEVNET_IP" ] || [ -z "$DEVNET_HTTP_PORT" ] || [ -z "$DEVNET_OMQ_PORT" ]; then
+            echo "ERROR: NETWORK_TARGET=devnet but not all DEVNET_* Actions variables are set"
+            echo "  DEVNET_PUBKEY set? $([ -n "$DEVNET_PUBKEY" ] && echo yes || echo NO)"
+            echo "  DEVNET_IP='$DEVNET_IP' DEVNET_HTTP_PORT='$DEVNET_HTTP_PORT' DEVNET_OMQ_PORT='$DEVNET_OMQ_PORT'"
+            exit 1
+          fi
+          SEED="http://${DEVNET_IP}:${DEVNET_HTTP_PORT}"
+          echo "Requested devnet -> probing seed node $SEED"
+          for attempt in 1 2 3; do
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "$SEED" 2>/dev/null || echo '000')
+            if [ "$CODE" != "000" ]; then echo "Devnet reachable (HTTP $CODE)"; exit 0; fi
+            echo "attempt $attempt/3 failed"; [ "$attempt" -lt 3 ] && sleep "$attempt"
+          done
+          echo "ERROR: devnet seed node $SEED not reachable after 3 attempts"; exit 1
 
       - name: Download ipa and extract it
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,15 @@ Only a subset matters per platform (all read in `run/test/utils/binaries.ts` /
   boot them); see `README.md`.
 - **Run tuning:** `PLAYWRIGHT_WORKERS_COUNT` (default 1), `PLAYWRIGHT_RETRIES_COUNT`
   (default 0), `PLAYWRIGHT_REPEAT_COUNT`.
-- iOS is always **mainnet** (`getNetworkTarget` in `devnet.ts` hardcodes it —
-  "iOS doesn't supply devnet builds yet"), so `IS_AUTOMATIC_QA` / devnet only affect
-  Android.
+- **Network target.** iOS defaults to **mainnet** but supports **testnet/devnet** too — set
+  `NETWORK_TARGET=mainnet|testnet|devnet` (same var the CI workflows/report use). `devnet` also
+  needs `DEVNET_PUBKEY`, `DEVNET_IP`, `DEVNET_HTTP_PORT`, `DEVNET_OMQ_PORT` (see `.env.sample`) and
+  a reachable devnet seed node; the app is pointed at it via launch-arg env keys
+  (`serviceNetwork`/`devnet*`, consumed by `DeveloperSettingsViewModel+Testing.swift` in
+  Session_iOS) and the seeder is pointed at the same seed URL (`getNetworkTarget` /
+  `getIosDevnetSeedUrl`). Running on devnet avoids full mainnet onion-routing latency, which
+  dominates the slowest multi-device tests. Android reaches devnet differently — it switches build
+  variant (`IS_AUTOMATIC_QA` / an AQA build) rather than reading `NETWORK_TARGET` in the harness.
 
 ### iOS simulators
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test-one": "_TESTING=1 _FORCE_LOGS=0 npx playwright test --grep",
     "test-udid": "_TESTING=1 npx playwright test UDID=$udid --grep",
     "test-ios": "_TESTING=1 npx playwright test --grep '@ios'",
+    "test-ios-parallel": "npx ts-node scripts/run_ios_parallel.ts",
     "test-android": "_TESTING=1 npx playwright test --grep '@android'",
     "test-one-logs": "_TESTING=1  _FORCELOGS=1 npx playwright test --retries 0 ./run/test/**/*.spec.ts --grep",
     "test-high-risk-android": "_TESTING=1 npx playwright test --grep '@android @high-risk'",

--- a/run/test/utils/capabilities_ios.ts
+++ b/run/test/utils/capabilities_ios.ts
@@ -17,6 +17,106 @@ type AppiumXCUITestCapabilities = Capabilities.AppiumXCUITestCapabilities;
 
 export const IOS_PRO_CONTEXT: IOSTestContext = { sessionProEnabled: 'true' };
 
+// --- Service network selection (mainnet / testnet / devnet) ---
+//
+// The iOS app (simulator build) reads `serviceNetwork` and, for devnet, the `devnet*` keys from
+// its launch-arg env (DeveloperSettingsViewModel.processUnitTestEnvVariablesIfNeeded in Session_iOS).
+// Running against a devnet avoids full mainnet onion-routing latency, which dominates the slowest
+// multi-device tests. Selection comes from NETWORK_TARGET (the same var the workflows/report use);
+// default stays mainnet so nothing changes unless NETWORK_TARGET is set.
+//
+// The devnet the *app* connects to (below) MUST be the same one the *seeder* points at
+// (see getNetworkTarget in devnet.ts, which uses getIosDevnetSeedUrl()).
+
+export type IosServiceNetwork = 'devnet' | 'mainnet' | 'testnet';
+
+export type IosDevnetConfig = {
+  pubkey: string;
+  ip: string;
+  httpPort: string;
+  omqPort: string;
+};
+
+export function getIosServiceNetwork(): IosServiceNetwork {
+  const raw = (process.env.NETWORK_TARGET ?? 'mainnet').trim().toLowerCase();
+  if (raw === 'mainnet' || raw === 'testnet' || raw === 'devnet') {
+    return raw;
+  }
+  throw new Error(
+    `Invalid NETWORK_TARGET "${process.env.NETWORK_TARGET}". Use mainnet | testnet | devnet.`
+  );
+}
+
+/**
+ * Devnet connection details for the iOS app, read from the environment. Mirrors the validation the
+ * app itself does, and throws (listing what's missing/invalid) so a misconfigured devnet run fails
+ * fast here rather than the app silently falling back to testnet.
+ */
+export function getIosDevnetConfig(): IosDevnetConfig {
+  const pubkey = (process.env.DEVNET_PUBKEY ?? '').trim();
+  const ip = (process.env.DEVNET_IP ?? '').trim();
+  const httpPort = (process.env.DEVNET_HTTP_PORT ?? '').trim();
+  const omqPort = (process.env.DEVNET_OMQ_PORT ?? '').trim();
+
+  const errors: string[] = [];
+  if (!/^[0-9a-fA-F]{64}$/.test(pubkey)) {
+    errors.push('DEVNET_PUBKEY must be a 64-character hex string');
+  }
+  const octets = ip.split('.');
+  if (octets.length !== 4 || !octets.every(o => /^\d{1,3}$/.test(o) && Number(o) <= 255)) {
+    errors.push('DEVNET_IP must be an IPv4 address like 10.0.0.1');
+  }
+  if (!/^\d{1,5}$/.test(httpPort) || Number(httpPort) > 65535) {
+    errors.push('DEVNET_HTTP_PORT must be a number between 0 and 65535');
+  }
+  if (!/^\d{1,5}$/.test(omqPort) || Number(omqPort) > 65535) {
+    errors.push('DEVNET_OMQ_PORT must be a number between 0 and 65535');
+  }
+  if (errors.length > 0) {
+    throw new Error(
+      `NETWORK_TARGET=devnet requires valid devnet env vars:\n  - ${errors.join('\n  - ')}`
+    );
+  }
+  return { pubkey, ip, httpPort, omqPort };
+}
+
+/** Seed-node URL the seeder should use for devnet (same devnet the app connects to). */
+export function getIosDevnetSeedUrl(): `http://${string}` {
+  const { ip, httpPort } = getIosDevnetConfig();
+  return `http://${ip}:${httpPort}`;
+}
+
+/** Extra processArguments.env keys that point the app at the selected service network. */
+function buildServiceNetworkEnv(): Record<string, string> {
+  const network = getIosServiceNetwork();
+  if (network === 'mainnet') {
+    return {}; // app default — nothing to set
+  }
+  if (network === 'testnet') {
+    return { serviceNetwork: 'testnet' };
+  }
+  const cfg = getIosDevnetConfig();
+  return {
+    serviceNetwork: 'devnet',
+    devnetPubkey: cfg.pubkey,
+    devnetIp: cfg.ip,
+    devnetHttpPort: cfg.httpPort,
+    devnetOmqPort: cfg.omqPort,
+  };
+}
+
+// Resolved lazily and memoised on first iOS capability build (NOT at module load): this file is
+// also imported on Android runs, where NETWORK_TARGET may be `devnet` — we must not try to read
+// (and throw on) the iOS-only DEVNET_* vars there. getIosCapabilities is iOS-only, so validation
+// happens exactly when/where it's relevant.
+let serviceNetworkEnvCache: Record<string, string> | undefined;
+function getServiceNetworkEnv(): Record<string, string> {
+  if (serviceNetworkEnvCache === undefined) {
+    serviceNetworkEnvCache = buildServiceNetworkEnv();
+  }
+  return serviceNetworkEnvCache;
+}
+
 const iosPathPrefix = process.env.IOS_APP_PATH_PREFIX;
 
 export const iOSBundleId = 'com.loki-project.loki-messenger';
@@ -160,9 +260,10 @@ export function getIosCapabilities(
     customEnv.sessionPro = customCaps.sessionProEnabled;
   }
 
-  // Rebuild the processArguments block with merged env vars
+  // Rebuild the processArguments block with merged env vars.
+  // The service-network env (mainnet/testnet/devnet selection) is layered under per-test customEnv.
   caps['appium:processArguments'] = {
-    env: { ...baseEnv, ...customEnv },
+    env: { ...baseEnv, ...getServiceNetworkEnv(), ...customEnv },
   };
 
   return {

--- a/run/test/utils/devnet.ts
+++ b/run/test/utils/devnet.ts
@@ -5,13 +5,14 @@ import type { SupportedPlatformsType } from './open_app';
 import { DEVNET_URL } from '../../constants';
 import { AppName } from '../../types/testing';
 import { getAndroidApk } from './binaries';
+import { getIosDevnetSeedUrl, getIosServiceNetwork } from './capabilities_ios';
 import { sleepFor } from './sleep_for';
 
 // NOTE this currently only applies to Android as iOS doesn't supply AQA builds yet
 type NetworkType = Parameters<typeof buildStateForTest>[2];
 
 // Using native fetch to check devnet accessibility
-async function isDevnetReachable(): Promise<boolean> {
+async function isDevnetReachable(url: string = DEVNET_URL): Promise<boolean> {
   const isCI = process.env.CI === '1';
   const maxAttempts = isCI ? 3 : 1;
   const timeout = isCI ? 10_000 : 2_000;
@@ -26,10 +27,10 @@ async function isDevnetReachable(): Promise<boolean> {
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-      const response = await fetch(DEVNET_URL, { signal: controller.signal });
+      const response = await fetch(url, { signal: controller.signal });
       clearTimeout(timeoutId);
 
-      console.log(`Internal devnet is accessible (HTTP ${response.status})`);
+      console.log(`Devnet ${url} is accessible (HTTP ${response.status})`);
       return true;
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : 'Unknown error';
@@ -57,7 +58,33 @@ export async function getNetworkTarget(platform: SupportedPlatformsType): Promis
     return process.env.DETECTED_NETWORK_TARGET as NetworkType;
   }
   if (platform === 'ios') {
-    process.env.DETECTED_NETWORK_TARGET = 'mainnet'; // iOS doesn't supply devnet builds yet
+    // iOS supports mainnet/testnet/devnet via the app's simulator launch-arg env
+    // (DeveloperSettingsViewModel+Testing.swift). Default is mainnet; opt into devnet/testnet
+    // with NETWORK_TARGET (+ DEVNET_* vars for devnet — see capabilities_ios.ts).
+    const network = getIosServiceNetwork();
+
+    if (network === 'devnet') {
+      const seedUrl = getIosDevnetSeedUrl();
+      const canAccessDevnet = await isDevnetReachable(seedUrl);
+      if (!canAccessDevnet) {
+        throw new Error(
+          `NETWORK_TARGET=devnet, but the devnet seed node at ${seedUrl} is not reachable. ` +
+            `Ensure the devnet is running/reachable, or set NETWORK_TARGET=mainnet.`
+        );
+      }
+      process.env.DETECTED_NETWORK_TARGET = seedUrl;
+      console.log(`Network target (iOS): devnet via ${seedUrl}`);
+      return seedUrl;
+    }
+
+    if (network === 'testnet') {
+      process.env.DETECTED_NETWORK_TARGET = 'testnet';
+      console.log('Network target (iOS): testnet');
+      return 'testnet';
+    }
+
+    process.env.DETECTED_NETWORK_TARGET = 'mainnet';
+    console.log('Network target (iOS): mainnet');
     return 'mainnet';
   }
   if (platform !== 'android') {

--- a/run/test/utils/open_app.ts
+++ b/run/test/utils/open_app.ts
@@ -276,30 +276,44 @@ const openiOSApp = async (
   device: DeviceWrapper;
 }> => {
   console.info('openiOSApp');
-  let actualCapabilitiesIndex: number;
   const parallelIndex = parseInt(process.env.TEST_PARALLEL_INDEX || '0');
-  if (process.env.CI === '1') {
-    // NOTE: This assumes DEVICES_PER_TEST_COUNT=4 is set in CI for iOS (not applicable to Android)
-    // Worker pools are fixed at 4 devices each regardless of actual test size:
-    // Worker 0: devices 0-3, Worker 1: devices 4-7, Worker 2: devices 8-11
-    const devicesPerWorker = getDevicesPerTestCount();
-    const workerBaseOffset = devicesPerWorker * parallelIndex;
 
-    // Apply retry offset, but wrap within the worker's device pool only
-    // This means when retrying, alice/bob etc won't be the same device as before within a worker's pool
-    // This is to avoid any issues where a device might be in a bad state for some reason
-    // (e.g. not accessing photo library on iOS)
-    const retryOffset = testInfo.retry || 0;
-    const deviceIndexWithinWorker = (capabilitiesIndex + retryOffset) % devicesPerWorker;
-    actualCapabilitiesIndex = workerBaseOffset + deviceIndexWithinWorker;
+  // Each Playwright worker owns a fixed pool of `DEVICES_PER_TEST_COUNT` simulators, offset by
+  // the worker's parallel index, so multiple workers never target the same simulator. This runs
+  // locally as well as on CI: with a single worker (parallelIndex 0) it collapses to devices
+  // 0..N-1, and with more workers it fans out (worker 0: devices 0-3, worker 1: 4-7, ...).
+  // To run >1 worker locally you must provision `workers * DEVICES_PER_TEST_COUNT` simulators —
+  // `pnpm test-ios-parallel` does this for you.
+  const devicesPerWorker = getDevicesPerTestCount();
 
-    if (retryOffset > 0) {
-      console.info(
-        `Retry offset applied (#${retryOffset}), rotating device allocations within worker`
-      );
-    }
-  } else {
-    actualCapabilitiesIndex = capabilitiesIndex;
+  // Guard: a test can only run if its device count fits within a single worker's pool. Without
+  // this, `capabilitiesIndex % devicesPerWorker` below would silently wrap and map two logical
+  // devices (e.g. alice and charlie) onto the SAME simulator, corrupting the test. Fail loudly
+  // with actionable guidance instead. (Never triggers on CI, where the pool of 4 covers the
+  // largest test.)
+  if (capabilitiesIndex >= devicesPerWorker) {
+    throw new Error(
+      `This test needs at least ${capabilitiesIndex + 1} devices, but each worker is allocated ` +
+        `only ${devicesPerWorker} simulator(s) (DEVICES_PER_TEST_COUNT=${devicesPerWorker}). ` +
+        `Re-run with a larger pool, e.g. \`pnpm test-ios-parallel --devices ${capabilitiesIndex + 1}\`, ` +
+        `or filter to tests that fit, e.g. \`--grep '@ios @${devicesPerWorker}-devices'\`.`
+    );
+  }
+
+  const workerBaseOffset = devicesPerWorker * parallelIndex;
+
+  // Apply retry offset, but wrap within the worker's device pool only.
+  // This means when retrying, alice/bob etc won't be the same device as before within a worker's
+  // pool, to avoid any issues where a device might be in a bad state for some reason
+  // (e.g. not accessing photo library on iOS).
+  const retryOffset = testInfo.retry || 0;
+  const deviceIndexWithinWorker = (capabilitiesIndex + retryOffset) % devicesPerWorker;
+  const actualCapabilitiesIndex = workerBaseOffset + deviceIndexWithinWorker;
+
+  if (retryOffset > 0) {
+    console.info(
+      `Retry offset applied (#${retryOffset}), rotating device allocations within worker`
+    );
   }
 
   const opts: XCUITestDriverOpts = {

--- a/scripts/cleanup_ios_simulators.ts
+++ b/scripts/cleanup_ios_simulators.ts
@@ -1,9 +1,8 @@
-import { execSync } from 'child_process';
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 
 import type { Simulator } from '../run/test/utils/capabilities_ios';
 
-import { shutdownSimulator } from './ios_shared';
+import { deleteSimulators } from './ios_shared';
 
 /**
  * iOS Simulator Cleanup Script
@@ -17,22 +16,6 @@ import { shutdownSimulator } from './ios_shared';
  * Usage:
  *   pnpm cleanup-simulators
  */
-function deleteSimulator(udids: string[] | string): number {
-  const udidArray = Array.isArray(udids) ? udids : [udids];
-  let deleted = 0;
-
-  for (const udid of udidArray) {
-    shutdownSimulator(udid);
-    try {
-      execSync(`xcrun simctl delete ${udid}`, { stdio: 'pipe' });
-      deleted++;
-    } catch {
-      console.warn(`Failed to delete: ${udid}`);
-    }
-  }
-
-  return deleted;
-}
 function cleanupFromJSON(): number {
   const jsonPath = 'ci-simulators.json';
 
@@ -47,7 +30,7 @@ function cleanupFromJSON(): number {
   }
 
   const simulators: Simulator[] = JSON.parse(readFileSync(jsonPath, 'utf-8'));
-  const deleted = deleteSimulator(simulators.map(sim => sim.udid));
+  const deleted = deleteSimulators(simulators.map(sim => sim.udid));
 
   unlinkSync(jsonPath);
   console.log(`✓ Removed ${jsonPath}`);
@@ -79,7 +62,7 @@ function cleanupFromEnv(): number {
     return 0;
   }
 
-  const deleted = deleteSimulator(udids);
+  const deleted = deleteSimulators(udids);
 
   // Remove simulator lines from .env
   const cleanedEnv =

--- a/scripts/create_ios_simulators.ts
+++ b/scripts/create_ios_simulators.ts
@@ -6,7 +6,12 @@ import type { Simulator } from '../run/test/utils/capabilities_ios';
 import type { DeviceWrapper } from '../run/types/DeviceWrapper';
 
 import { copyFileToSimulator } from '../run/test/utils/copy_file_to_simulator';
-import { bootSimulator, isSimulatorBooted, shutdownSimulator } from './ios_shared';
+import {
+  bootSimulator,
+  isSimulatorBooted,
+  resolveIosRuntime,
+  shutdownSimulator,
+} from './ios_shared';
 import { sleepSync } from './shared';
 
 /**
@@ -32,15 +37,38 @@ import { sleepSync } from './shared';
 type SimulatorConfig = {
   deviceType: string;
   runtime: string;
+  name: string;
   totalSimulators: number;
 };
 
-// Define the device type and runtime to create
-const DEVICE_CONFIG = {
+// Default device type + runtime. The runtime is a *preference*: if it isn't installed we fall
+// back to the newest installed iOS runtime (see resolveDeviceConfig). Both can be overridden via
+// the IOS_SIM_DEVICE_TYPE / IOS_SIM_RUNTIME env vars (or `--runtime` on run_ios_parallel).
+const DEVICE_CONFIG_DEFAULTS = {
   type: 'iPhone 17',
-  name: '17',
   runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-26-2', // xcrun simctl list runtimes
 };
+
+/**
+ * Resolve the device type + runtime to create simulators against, applying overrides and
+ * falling back to the newest installed iOS runtime when the preferred one is missing.
+ *
+ * @param overrides.runtime a friendly version ("26.1") or full runtime identifier
+ * @param overrides.deviceType e.g. "iPhone 16e"
+ */
+export function resolveDeviceConfig(overrides?: { runtime?: string; deviceType?: string }): {
+  deviceType: string;
+  runtime: string;
+  name: string;
+} {
+  const deviceType =
+    overrides?.deviceType ?? process.env.IOS_SIM_DEVICE_TYPE ?? DEVICE_CONFIG_DEFAULTS.type;
+  const runtimeOverride = overrides?.runtime ?? process.env.IOS_SIM_RUNTIME;
+  const runtime = resolveIosRuntime(DEVICE_CONFIG_DEFAULTS.runtime, runtimeOverride);
+  // `name` is only a cosmetic prefix for the simulator name (e.g. "Auto-17-0").
+  const name = deviceType.replace(/^iPhone\s*/i, '').trim() || deviceType;
+  return { deviceType, runtime: runtime.identifier, name };
+}
 
 const MEDIA_ROOT = path.join('run', 'test', 'media');
 const MEDIA_FILES = {
@@ -105,7 +133,12 @@ function preloadMedia(udid: string): void {
 // Create N number of pre-loaded simulators by:
 // Creating one "template" simulator, booting it, copying media over, shutting it down and then cloning it N-1 times
 // (You can't copy to shutdown simulators and you can't clone booted simulators)
-function createIOSSimulators(config: SimulatorConfig): Simulator[] {
+//
+// NOTE: this only creates the simulators and returns them (all left shut down — Appium boots
+// them on demand). Persisting the config (.env / ci-simulators.json) is the caller's job, so
+// that callers which manage their own simulator lifecycle (e.g. run_ios_parallel.ts) can create
+// throwaway simulators without clobbering the developer's .env.
+export function createIOSSimulators(config: SimulatorConfig): Simulator[] {
   console.log(`\nCreating ${config.totalSimulators} iOS simulators\n`);
 
   const startTime = Date.now();
@@ -114,7 +147,7 @@ function createIOSSimulators(config: SimulatorConfig): Simulator[] {
   // Create Simulator 0 with preloaded media
   console.log(`Creating Simulator 0 with preloaded media...`);
 
-  const name0 = `Auto-${DEVICE_CONFIG.name}-0`;
+  const name0 = `Auto-${config.name}-0`;
   const udid0 = createSimulator(name0, config.deviceType, config.runtime);
 
   if (!bootSimulator(udid0)) {
@@ -140,7 +173,7 @@ function createIOSSimulators(config: SimulatorConfig): Simulator[] {
   console.log(`Cloning ${config.totalSimulators - 1} more Simulators...`);
 
   for (let index = 1; index < config.totalSimulators; index++) {
-    const name = `Auto-${DEVICE_CONFIG.name}-${index}`;
+    const name = `Auto-${config.name}-${index}`;
     const udid = cloneSimulator(udid0, name);
 
     simulators.push({
@@ -155,11 +188,10 @@ function createIOSSimulators(config: SimulatorConfig): Simulator[] {
   const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
   console.log(`\n✓ Created ${simulators.length} Simulators in ${totalTime}s`);
 
-  saveSimulatorConfig(simulators);
   return simulators;
 }
 
-function updateLocalEnvFile(simulators: Simulator[]): void {
+export function updateLocalEnvFile(simulators: Simulator[]): void {
   const envPath = '.env';
   let envContent = existsSync(envPath) ? readFileSync(envPath, 'utf-8') : '';
 
@@ -177,7 +209,7 @@ function updateLocalEnvFile(simulators: Simulator[]): void {
   writeFileSync(envPath, envContent);
 }
 
-function saveSimulatorConfig(simulators: Simulator[]): void {
+export function saveSimulatorConfig(simulators: Simulator[]): void {
   // For running on CI, create a json file that GHA can read the UDIDs from
   if (process.env.CI === '1') {
     writeFileSync('ci-simulators.json', JSON.stringify(simulators, null, 2));
@@ -189,31 +221,32 @@ function saveSimulatorConfig(simulators: Simulator[]): void {
   }
 }
 
-// Main execution
-const numSimulatorsArg = process.argv[2];
+// Main execution (only when invoked directly, e.g. `pnpm create-simulators`).
+// When imported as a module (e.g. by run_ios_parallel.ts) this block does not run.
+if (require.main === module) {
+  const numSimulatorsArg = process.argv[2];
 
-if (!numSimulatorsArg) {
-  console.error('Error: Number of Simulators required');
-  console.error('Usage: pnpm create-simulators <number>');
-  process.exit(1);
-}
+  if (!numSimulatorsArg) {
+    console.error('Error: Number of Simulators required');
+    console.error('Usage: pnpm create-simulators <number>');
+    process.exit(1);
+  }
 
-const numSimulators = parseInt(numSimulatorsArg);
+  const numSimulators = parseInt(numSimulatorsArg);
 
-if (isNaN(numSimulators) || numSimulators < 1) {
-  console.error('Error: Invalid number of Simulators');
-  console.error('Usage: pnpm create-simulators <number>');
-  process.exit(1);
-}
+  if (isNaN(numSimulators) || numSimulators < 1) {
+    console.error('Error: Invalid number of Simulators');
+    console.error('Usage: pnpm create-simulators <number>');
+    process.exit(1);
+  }
 
-try {
-  createIOSSimulators({
-    deviceType: DEVICE_CONFIG.type,
-    runtime: DEVICE_CONFIG.runtime,
-    totalSimulators: numSimulators,
-  });
-} catch (error) {
-  console.error('\n✗ Failed to create Simulators');
-  console.error(error);
-  process.exit(1);
+  try {
+    const deviceConfig = resolveDeviceConfig();
+    const sims = createIOSSimulators({ ...deviceConfig, totalSimulators: numSimulators });
+    saveSimulatorConfig(sims);
+  } catch (error) {
+    console.error('\n✗ Failed to create Simulators');
+    console.error(error);
+    process.exit(1);
+  }
 }

--- a/scripts/ios_shared.ts
+++ b/scripts/ios_shared.ts
@@ -1,6 +1,88 @@
 import { execSync } from 'child_process';
 import { chunk } from 'lodash';
 
+export type IosRuntime = { identifier: string; version: string };
+
+type SimctlRuntimeEntry = {
+  identifier: string;
+  version: string;
+  isAvailable?: boolean;
+};
+
+/** Compare two dotted version strings numerically (e.g. "26.1" > "18.6"). */
+function compareVersionsDesc(a: string, b: string): number {
+  const pa = a.split('.').map(n => parseInt(n) || 0);
+  const pb = b.split('.').map(n => parseInt(n) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pb[i] ?? 0) - (pa[i] ?? 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+/** All installed, available iOS simulator runtimes, newest first. */
+export function listAvailableIosRuntimes(): IosRuntime[] {
+  const raw = execSync('xcrun simctl list runtimes --json', { encoding: 'utf-8' });
+  const parsed = JSON.parse(raw) as { runtimes: SimctlRuntimeEntry[] };
+  return parsed.runtimes
+    .filter(r => r.isAvailable !== false && r.identifier.includes('SimRuntime.iOS-'))
+    .map(r => ({ identifier: r.identifier, version: r.version }))
+    .sort((a, b) => compareVersionsDesc(a.version, b.version));
+}
+
+/** Turn a friendly override ("26.1") or a full identifier into a runtime identifier. */
+function normaliseRuntimeOverride(override: string): string {
+  const trimmed = override.trim();
+  if (trimmed.startsWith('com.apple')) {
+    return trimmed;
+  }
+  return `com.apple.CoreSimulator.SimRuntime.iOS-${trimmed.replace(/\./g, '-')}`;
+}
+
+/**
+ * Resolve which iOS runtime to create simulators against.
+ * - `override` (a version like "26.1" or a full identifier) must be installed, else we throw
+ *   with the list of what IS installed.
+ * - Otherwise we use `preferredIdentifier` if installed, and fall back to the newest installed
+ *   iOS runtime if not (logging a notice). This keeps things working when Apple bumps versions.
+ */
+export function resolveIosRuntime(preferredIdentifier: string, override?: string): IosRuntime {
+  const available = listAvailableIosRuntimes();
+  if (available.length === 0) {
+    throw new Error(
+      'No iOS simulator runtimes are installed. Install one via Xcode > Settings > Components.'
+    );
+  }
+
+  if (override) {
+    const wanted = normaliseRuntimeOverride(override);
+    const match = available.find(r => r.identifier === wanted);
+    if (!match) {
+      throw new Error(
+        `Requested iOS runtime "${override}" (${wanted}) is not installed.\n` +
+          `Available iOS runtimes: ${available.map(r => r.version).join(', ')}`
+      );
+    }
+    return match;
+  }
+
+  const preferred = available.find(r => r.identifier === preferredIdentifier);
+  if (preferred) {
+    return preferred;
+  }
+
+  const newest = available[0];
+  console.warn(
+    `Preferred iOS runtime (${preferredIdentifier}) is not installed; falling back to the ` +
+      `newest available: iOS ${newest.version}. Set IOS_SIM_RUNTIME=<version> (or pass ` +
+      `--runtime) to choose a specific one.`
+  );
+  return newest;
+}
+
 export function getSimulatorUDID(index: number) {
   const envVar = `IOS_${index}_SIMULATOR`;
   return process.env[envVar];
@@ -71,4 +153,26 @@ export function shutdownSimulator(udid: string): void {
   } catch {
     // Already shutdown or doesn't exist - this is fine
   }
+}
+
+/**
+ * Shut down (if needed) and delete the given simulator UDIDs. Returns the number successfully
+ * deleted. Never throws — a simulator that is already gone is treated as success-adjacent and
+ * simply skipped, so this is safe to call from cleanup/signal handlers.
+ */
+export function deleteSimulators(udids: string[] | string): number {
+  const udidArray = Array.isArray(udids) ? udids : [udids];
+  let deleted = 0;
+
+  for (const udid of udidArray) {
+    shutdownSimulator(udid);
+    try {
+      execSync(`xcrun simctl delete ${udid}`, { stdio: 'pipe' });
+      deleted++;
+    } catch {
+      console.warn(`Failed to delete simulator: ${udid}`);
+    }
+  }
+
+  return deleted;
 }

--- a/scripts/run_ios_parallel.ts
+++ b/scripts/run_ios_parallel.ts
@@ -1,0 +1,223 @@
+import { spawn } from 'child_process';
+import dotenv from 'dotenv';
+
+import type { Simulator } from '../run/test/utils/capabilities_ios';
+
+import { createIOSSimulators, resolveDeviceConfig } from './create_ios_simulators';
+import { deleteSimulators } from './ios_shared';
+
+/**
+ * Self-contained parallel iOS test runner.
+ *
+ * Creates a throwaway pool of media-preloaded simulators, runs the iOS suite across multiple
+ * Playwright workers against them, then deletes the simulators when the run finishes OR is
+ * cancelled (Ctrl+C). Pass `--keep` to leave the simulators (and their logs) behind for
+ * inspection or for reuse with `pnpm test-ios`.
+ *
+ * Why this exists: locally the suite runs single-worker, so ~250 iOS tests execute one at a
+ * time. Each Playwright worker owns a fixed pool of `--devices` simulators (offset by its
+ * worker index — see openiOSApp in open_app.ts), so N workers need N * devices simulators.
+ * This script provisions exactly that many, wires their UDIDs into the child process's
+ * environment (without touching your .env), and cleans up after itself.
+ *
+ * Usage:
+ *   pnpm test-ios-parallel                          # 2 workers x 2 devices (4 sims), grep @ios
+ *   pnpm test-ios-parallel --devices 4              # 2 workers x 4 devices (8 sims)
+ *   pnpm test-ios-parallel --workers 3 --devices 4  # 3 workers x 4 devices (12 sims)
+ *   pnpm test-ios-parallel --grep '@ios @high-risk' # subset
+ *   pnpm test-ios-parallel --keep                   # don't delete simulators afterwards
+ *   pnpm test-ios-parallel --runtime 26.1           # pin the iOS runtime (default: newest)
+ *   pnpm test-ios-parallel --network devnet         # run against devnet (needs DEVNET_* in .env)
+ *   pnpm test-ios-parallel --workers 2 -- --repeat-each 2   # args after `--` go to Playwright
+ *
+ * Notes:
+ *   - `--network` selects the service network (mainnet | testnet | devnet; default mainnet).
+ *     devnet also requires DEVNET_PUBKEY / DEVNET_IP / DEVNET_HTTP_PORT / DEVNET_OMQ_PORT in .env
+ *     (see .env.sample) and a reachable devnet — running against devnet avoids full mainnet
+ *     onion-routing latency, the dominant cost of the slowest multi-device tests.
+ *   - `--runtime` picks the iOS simulator runtime (a version like "26.1" or a full identifier).
+ *     If omitted, the preferred runtime is used when installed, otherwise the newest installed
+ *     iOS runtime. Device type is overridable via the IOS_SIM_DEVICE_TYPE env var.
+ *   - `--devices` is the per-worker simulator pool. It must be >= the largest test's device
+ *     count in your grep, otherwise those tests fail fast with a clear error (see openiOSApp).
+ *     The default of 2 covers @1-devices / @2-devices tests; use `--devices 4` to include the
+ *     @3-devices / @4-devices tests (i.e. the full suite).
+ *   - Simulators are created shut down; Appium boots each on demand at session start (as on CI).
+ *   - Total simulators (workers * devices) must not exceed 12 (the IOS_N_SIMULATOR cap).
+ *   - Creating simulators has a one-off cost (clone + media). For fast iteration, run once with
+ *     `--keep`, paste the printed IOS_N_SIMULATOR lines into .env, then use `pnpm test-ios`.
+ */
+
+dotenv.config({ quiet: true });
+
+const MAX_SIMULATORS = 12;
+
+type ParsedArgs = {
+  workers: number;
+  devicesPerTest: number;
+  grep: string;
+  keep: boolean;
+  runtime?: string;
+  network?: string;
+  passthrough: string[];
+};
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const args: ParsedArgs = {
+    workers: 2,
+    devicesPerTest: 2,
+    grep: '@ios',
+    keep: false,
+    passthrough: [],
+  };
+
+  // Everything after a lone `--` is forwarded verbatim to Playwright.
+  const sepIndex = argv.indexOf('--');
+  const ownArgs = sepIndex === -1 ? argv : argv.slice(0, sepIndex);
+  if (sepIndex !== -1) {
+    args.passthrough = argv.slice(sepIndex + 1);
+  }
+
+  // Accepts both `--flag value` and `--flag=value`.
+  const readValue = (current: string, next: string | undefined): [string, boolean] => {
+    const eq = current.indexOf('=');
+    if (eq !== -1) {
+      return [current.slice(eq + 1), false];
+    }
+    return [next ?? '', true];
+  };
+
+  for (let i = 0; i < ownArgs.length; i++) {
+    const arg = ownArgs[i];
+    if (arg === '--keep') {
+      args.keep = true;
+    } else if (arg.startsWith('--workers')) {
+      const [value, consumedNext] = readValue(arg, ownArgs[i + 1]);
+      args.workers = parseInt(value);
+      if (consumedNext) i++;
+    } else if (arg.startsWith('--devices')) {
+      const [value, consumedNext] = readValue(arg, ownArgs[i + 1]);
+      args.devicesPerTest = parseInt(value);
+      if (consumedNext) i++;
+    } else if (arg.startsWith('--grep')) {
+      const [value, consumedNext] = readValue(arg, ownArgs[i + 1]);
+      args.grep = value;
+      if (consumedNext) i++;
+    } else if (arg.startsWith('--runtime')) {
+      const [value, consumedNext] = readValue(arg, ownArgs[i + 1]);
+      args.runtime = value;
+      if (consumedNext) i++;
+    } else if (arg.startsWith('--network')) {
+      const [value, consumedNext] = readValue(arg, ownArgs[i + 1]);
+      args.network = value;
+      if (consumedNext) i++;
+    } else {
+      console.error(`Unknown argument: "${arg}". Forward Playwright args after a "--" separator.`);
+      process.exit(1);
+    }
+  }
+
+  return args;
+}
+
+function validate(args: ParsedArgs): number {
+  if (!process.env.IOS_APP_PATH_PREFIX) {
+    console.error('IOS_APP_PATH_PREFIX is not set — point it at a simulator Session.app first.');
+    process.exit(1);
+  }
+  if (isNaN(args.workers) || args.workers < 1) {
+    console.error(`Invalid --workers value: ${args.workers}`);
+    process.exit(1);
+  }
+  if (isNaN(args.devicesPerTest) || args.devicesPerTest < 1) {
+    console.error(`Invalid --devices value: ${args.devicesPerTest}`);
+    process.exit(1);
+  }
+  const totalSimulators = args.workers * args.devicesPerTest;
+  if (totalSimulators > MAX_SIMULATORS) {
+    console.error(
+      `Requested ${args.workers} workers x ${args.devicesPerTest} devices = ${totalSimulators} ` +
+        `simulators, but the maximum is ${MAX_SIMULATORS}. Lower --workers or --devices.`
+    );
+    process.exit(1);
+  }
+  return totalSimulators;
+}
+
+function printKeepInfo(simulators: Simulator[]): void {
+  console.log(`\nLeaving ${simulators.length} simulator(s) in place (--keep).`);
+  console.log('To reuse them with `pnpm test-ios`, put these lines in your .env:\n');
+  simulators.forEach((sim, i) => console.log(`IOS_${i + 1}_SIMULATOR=${sim.udid}`));
+  console.log('\nSimulator diagnostic logs live under ~/Library/Logs/CoreSimulator/<udid>/');
+  console.log('Delete them later with `pnpm cleanup-simulators` (after adding them to .env) or');
+  console.log('`xcrun simctl delete <udid>`.\n');
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const totalSimulators = validate(args);
+
+  console.log(
+    `\nProvisioning ${totalSimulators} simulator(s) for ${args.workers} worker(s) ` +
+      `x ${args.devicesPerTest} device(s)...`
+  );
+
+  const deviceConfig = resolveDeviceConfig({ runtime: args.runtime });
+  const simulators = createIOSSimulators({ ...deviceConfig, totalSimulators });
+
+  // Inject the freshly-created UDIDs into the child's environment only. capabilities_ios reads
+  // IOS_N_SIMULATOR from process.env; dotenv.config() there does NOT override already-set vars,
+  // so these win over any .env entries and the developer's .env is left untouched.
+  const childEnv: NodeJS.ProcessEnv = { ...process.env };
+  simulators.forEach((sim, i) => {
+    childEnv[`IOS_${i + 1}_SIMULATOR`] = sim.udid;
+  });
+  childEnv.PLATFORM = 'ios';
+  childEnv.PLAYWRIGHT_WORKERS_COUNT = String(args.workers);
+  childEnv.DEVICES_PER_TEST_COUNT = String(args.devicesPerTest);
+  childEnv._TESTING = childEnv._TESTING ?? '1';
+  // Service network selection (mainnet default). Devnet also needs DEVNET_* vars in .env — see
+  // capabilities_ios.ts / .env.sample. Left unset here so .env's NETWORK_TARGET is respected.
+  if (args.network) {
+    childEnv.NETWORK_TARGET = args.network;
+  }
+
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (cleanedUp) {
+      return;
+    }
+    cleanedUp = true;
+    if (args.keep) {
+      printKeepInfo(simulators);
+      return;
+    }
+    console.log('\nDeleting temporary simulators...');
+    const deleted = deleteSimulators(simulators.map(s => s.udid));
+    console.log(`✓ Deleted ${deleted} simulator(s)`);
+  };
+
+  const playwrightArgs = ['playwright', 'test', '--grep', args.grep, ...args.passthrough];
+  console.log(`\nRunning: npx ${playwrightArgs.join(' ')}\n`);
+
+  const child = spawn('npx', playwrightArgs, { stdio: 'inherit', env: childEnv });
+
+  // Forward interrupts to the child; its 'exit' below then triggers cleanup exactly once.
+  const forward = (signal: NodeJS.Signals) => () => child.kill(signal);
+  process.on('SIGINT', forward('SIGINT'));
+  process.on('SIGTERM', forward('SIGTERM'));
+
+  child.on('error', err => {
+    console.error('Failed to start Playwright:', err);
+    cleanup();
+    process.exit(1);
+  });
+
+  child.on('exit', (code, signal) => {
+    cleanup();
+    // Preserve the child's exit status so CI/other callers see the real result.
+    process.exit(code ?? (signal ? 1 : 0));
+  });
+}
+
+main();


### PR DESCRIPTION
Speed up local iOS regression runs and let the harness target mainnet/testnet/devnet instead of being hard-pinned to mainnet.

Local parallelism
- Unify iOS device allocation in openiOSApp so the per-worker simulator offset applies locally as well as on CI, making PLAYWRIGHT_WORKERS_COUNT>1 safe locally (single-worker behaviour unchanged). Throw a clear error when a test needs more devices than the per-worker pool instead of silently wrapping two logical devices onto the same simulator.
- Add `pnpm test-ios-parallel` (scripts/run_ios_parallel.ts): provisions a throwaway pool of media-preloaded simulators, runs the suite across N workers, then deletes them on exit/Ctrl+C (--keep to retain). Flags: --workers, --devices, --grep, --network, --runtime, --keep.

Configurable service network (mainnet/testnet/devnet)
- iOS is no longer hard-pinned to mainnet: select via NETWORK_TARGET. devnet also reads DEVNET_PUBKEY/DEVNET_IP/DEVNET_HTTP_PORT/DEVNET_OMQ_PORT and the app is pointed at it via the serviceNetwork/devnet* launch-arg env keys; the seeder targets the same seed URL. Resolution is lazy so importing on Android (which also sets NETWORK_TARGET) never touches the iOS-only vars.
- ios-regression.yml: add NETWORK_TARGET input (devnet/testnet/mainnet) with a fail-fast devnet reachability probe; devnet connection details come from repo-level Actions variables.

Simulator creation robustness
- Resolve the runtime/device type from env (IOS_SIM_RUNTIME / IOS_SIM_DEVICE_TYPE) with auto-fallback to the newest installed iOS runtime, fixing hard failures when the pinned runtime (iOS-26-2) isn't installed. Share deleteSimulators() between the create/cleanup scripts.

Docs
- CLAUDE.md/.env.sample: document NETWORK_TARGET + DEVNET_* and correct the stale "iOS is always mainnet" note.