### PR TITLE
feat(ios): custom file server support + correct devnet seed ports

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,9 +14,19 @@ UPDATE_BASELINES='false' # true auto-saves missing baseline screenshots
 
 # Service network (mainnet default). Set to devnet/testnet to avoid full mainnet
 # onion-routing latency (the dominant cost of the slowest multi-device tests).
-# devnet requires all four DEVNET_* values below AND a reachable devnet (see CLAUDE.md).
+# devnet requires all DEVNET_* values below AND a reachable devnet. Full guide + how to read
+# these off the devnet's node table: docs/local-devnet-ios.md.
+# The seed node is ONE node exposing three ports the tests use: oxend RPC (seeder), storage HTTPS
+# and storage OMQ (both used by the app). Example values are for the `oxend@1280` node.
 # NETWORK_TARGET=devnet
-# DEVNET_PUBKEY=<64-char hex seed-node pubkey>
-# DEVNET_IP=10.0.0.1
-# DEVNET_HTTP_PORT=1280
-# DEVNET_OMQ_PORT=<seed-node OMQ/QUIC port>
+# DEVNET_PUBKEY=<64-char hex seed-node ed25519 pubkey>   # "Pubkey" column
+# DEVNET_IP=10.0.0.1                                     # "IP" column
+# DEVNET_RPC_PORT=1280    # "IP:RPC" column      — seed oxend RPC, used by the seeder
+# DEVNET_HTTP_PORT=1300   # "Storage HTTPS" column — used by the app (devnetHttpPort)
+# DEVNET_OMQ_PORT=1305    # "Storage OMQ" column   — used by the app (devnetOmqPort/QUIC)
+#
+# Optional local file server (speeds media tests). FILE_SERVER_PUBKEY is the server's X25519
+# pubkey (libsession uses it directly as the x25519 encryption key — NOT the ed25519). Omit to use
+# the app's default file-server pubkey.
+# FILE_SERVER_URL=http://10.0.0.1:8000
+# FILE_SERVER_PUBKEY=<64-char hex X25519 pubkey>

--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -99,12 +99,13 @@ jobs:
       # For devnet the app also needs the seed-node connection details below; they are only read
       # when devnet is selected, so they are harmless on mainnet/testnet runs. Store them as
       # repo-level Actions *variables* (the pubkey is public; the IP/ports are internal), e.g.
-      # Settings > Secrets and variables > Actions. DEVNET_IP must be the address the runner can
-      # reach (the same devnet as Android's sesh-net.local:1280); the seeder derives its seed URL
-      # from DEVNET_IP:DEVNET_HTTP_PORT.
+      # Settings > Secrets and variables > Actions. The seed node exposes three ports the tests use:
+      # DEVNET_RPC_PORT (oxend RPC — the seeder), DEVNET_HTTP_PORT (storage HTTPS — the app) and
+      # DEVNET_OMQ_PORT (storage OMQ/QUIC — the app). See docs/local-devnet-ios.md.
       NETWORK_TARGET: ${{ github.event.inputs.NETWORK_TARGET }}
       DEVNET_PUBKEY: ${{ vars.DEVNET_PUBKEY }}
       DEVNET_IP: ${{ vars.DEVNET_IP }}
+      DEVNET_RPC_PORT: ${{ vars.DEVNET_RPC_PORT }}
       DEVNET_HTTP_PORT: ${{ vars.DEVNET_HTTP_PORT }}
       DEVNET_OMQ_PORT: ${{ vars.DEVNET_OMQ_PORT }}
       _TESTING: 1 # Always hide webdriver logs (@appium/support/ flag)
@@ -134,13 +135,14 @@ jobs:
         if: ${{ github.event.inputs.NETWORK_TARGET == 'devnet' }}
         shell: bash
         run: |
-          if [ -z "$DEVNET_PUBKEY" ] || [ -z "$DEVNET_IP" ] || [ -z "$DEVNET_HTTP_PORT" ] || [ -z "$DEVNET_OMQ_PORT" ]; then
+          if [ -z "$DEVNET_PUBKEY" ] || [ -z "$DEVNET_IP" ] || [ -z "$DEVNET_RPC_PORT" ] || [ -z "$DEVNET_HTTP_PORT" ] || [ -z "$DEVNET_OMQ_PORT" ]; then
             echo "ERROR: NETWORK_TARGET=devnet but not all DEVNET_* Actions variables are set"
             echo "  DEVNET_PUBKEY set? $([ -n "$DEVNET_PUBKEY" ] && echo yes || echo NO)"
-            echo "  DEVNET_IP='$DEVNET_IP' DEVNET_HTTP_PORT='$DEVNET_HTTP_PORT' DEVNET_OMQ_PORT='$DEVNET_OMQ_PORT'"
+            echo "  DEVNET_IP='$DEVNET_IP' DEVNET_RPC_PORT='$DEVNET_RPC_PORT' DEVNET_HTTP_PORT='$DEVNET_HTTP_PORT' DEVNET_OMQ_PORT='$DEVNET_OMQ_PORT'"
             exit 1
           fi
-          SEED="http://${DEVNET_IP}:${DEVNET_HTTP_PORT}"
+          # Probe the seeder's endpoint (oxend RPC); the app's storage ports are validated in-harness.
+          SEED="http://${DEVNET_IP}:${DEVNET_RPC_PORT}"
           echo "Requested devnet -> probing seed node $SEED"
           for attempt in 1 2 3; do
             CODE=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "$SEED" 2>/dev/null || echo '000')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Only a subset matters per platform (all read in `run/test/utils/binaries.ts` /
   `getIosDevnetSeedUrl`). Running on devnet avoids full mainnet onion-routing latency, which
   dominates the slowest multi-device tests. Android reaches devnet differently — it switches build
   variant (`IS_AUTOMATIC_QA` / an AQA build) rather than reading `NETWORK_TARGET` in the harness.
+  Local devnet setup (incl. OrbStack on the same Mac as the simulators): `docs/local-devnet-ios.md`.
 
 ### iOS simulators
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Prerequisites: Xcode installed and the appropriate simulator runtime available -
    IOS_APP_PATH_PREFIX=/path/to/Session.app
    ```
 
+> **Faster runs against a local devnet:** the slowest multi-device tests are bound by mainnet
+> network latency. To run the iOS suite against a local devnet instead, see
+> [docs/local-devnet-ios.md](docs/local-devnet-ios.md).
+
 ### Environment Configuration
 
 ```bash

--- a/docs/local-devnet-ios.md
+++ b/docs/local-devnet-ios.md
@@ -1,0 +1,195 @@
+# Running the iOS suite against a local devnet
+
+By default the iOS suite runs against **mainnet**, where message/config propagation is onion-routed
+over the real network — this dominates the wall-clock of the slowest multi-device tests. Pointing
+the suite at a **local devnet** (the [Sesh-Net-Docker](https://github.com/Bilb/sesh-net-docker)
+stack: ~12 oxend service nodes + storage servers) removes most of that latency.
+
+This guide covers running that devnet **on the same Mac as the simulators** using
+[OrbStack](https://orbstack.dev/). The harness support is already in place
+(`NETWORK_TARGET=devnet` + `DEVNET_*`, see [Environment](#environment)); the work is operational.
+
+> If you only need CI, you don't need any of this locally — CI reaches a Linux-hosted devnet over
+> the network via repo Actions variables. See [CI](#ci).
+
+## The one rule that makes or breaks it
+
+Each snode binds to `LISTEN_IP` **and advertises that exact IP in the service-node registry**
+(`--service-node-public-ip=$LISTEN_IP`). The client (the simulator) fetches the registry from the
+seed and then connects to whatever IP it finds there. So:
+
+> **`LISTEN_IP` must be an address that is (1) bindable inside the Linux VM and (2) reachable from
+> macOS at the _identical_ address.**
+
+Plain port-forwarding can't satisfy this — the registry still hands the client the VM-internal IP,
+so the address wouldn't match. This is exactly why Docker Desktop doesn't work here and OrbStack
+does: OrbStack routes macOS ↔ VM/container IPs transparently, so the VM has a macOS-reachable IP you
+can bind to. (iOS simulators use the Mac's network stack, so anything the Mac can reach, the
+simulator can reach too — no NAT dance like Android emulators.)
+
+## Prerequisites
+
+- OrbStack installed and running.
+- Sesh-Net-Docker cloned with submodules
+
+## 1. Choose `LISTEN_IP`
+
+Pick whichever fits; both leave CI untouched (CI just uses a different value — see [CI](#ci)).
+
+- **OrbStack VM IP (simplest, local-only) — recommended.** OrbStack runs a single shared Linux VM
+  that is up whenever OrbStack is running (you do **not** need the devnet compose for it to exist),
+  and macOS sits on the same subnet as that VM — so its `eth0` IP is reachable from macOS (and
+  therefore the simulators). Read it with a throwaway container:
+
+  ```bash
+  LISTEN_IP=$(docker run --rm --network host alpine \
+    ip -4 -o addr show eth0 | awk '{sub(/\/.*/,"",$4); print $4}')
+  echo "$LISTEN_IP"   # e.g. 192.168.139.2
+  ```
+
+  This value is stable across restarts for a given OrbStack install (it's the VM's fixed address),
+  so it's a discover-once value you can paste into `.env`. It differs per machine/OrbStack version,
+  which is why you read it rather than hardcode it. Keep the compose's `network_mode: host`; the
+  snodes bind to and advertise this IP, and macOS reaches it directly. (Verified: a host-network
+  service bound to this IP responds to `curl`/`ping` from macOS.)
+
+- **Tailscale IP (best local/CI parity).** Give the devnet its own tailnet identity (run
+  `tailscaled` in the container: `network_mode: host` + `cap_add: [NET_ADMIN]` + `/dev/net/tun`,
+  which OrbStack supports) and use its `100.x` address. Then local and CI are identical, and it's
+  reachable from other machines too — at the cost of more moving parts.
+
+## 2. Start the devnet
+
+From the Sesh-Net-Docker **repo root** (the parent compose starts the devnet **and** the file
+server — see [4b](#4b-optional-local-file-server)):
+
+```bash
+LISTEN_IP=<chosen-ip> docker compose up --build     # add -d to detach
+docker compose logs -f                              # wait for "You can send a command over RPC like"
+```
+
+(Devnet only? `cd sesh-net && LISTEN_IP=<chosen-ip> docker compose up --build`.)
+
+It prints a node table (`Name, SN, Pubkey, IP:RPC, P2P, ZMQ, QNET, Storage OMQ, Storage HTTPS`) —
+the source for the values below. Pick any `SN: Yes` row as the seed; the `oxend@1280` row is the
+conventional choice (it matches the devnet's own readiness probe and Android's `:1280`).
+
+## 3. Capture the `DEVNET_*` values
+
+The seed is **one node** that the app and the seeder reach on **different ports**, so three ports
+come from its row (example values are the `oxend@1280` row):
+
+| `.env` var         | From column          | Used by                     | Example         |
+| ------------------ | -------------------- | --------------------------- | --------------- |
+| `DEVNET_PUBKEY`    | `Pubkey`             | app                         | `a9713f93…a036` |
+| `DEVNET_IP`        | `IP` (= `LISTEN_IP`) | both                        | `192.168.139.2` |
+| `DEVNET_RPC_PORT`  | `IP:RPC`             | seeder (oxend `/json_rpc`)  | `1280`          |
+| `DEVNET_HTTP_PORT` | `Storage HTTPS`      | app (`devnetHttpPort`)      | `1300`          |
+| `DEVNET_OMQ_PORT`  | `Storage OMQ`        | app (`devnetOmqPort`, QUIC) | `1305`          |
+
+> **Why three ports:** the seeder calls `get_service_nodes` on the node's **oxend RPC**
+> (`DEVNET_RPC_PORT`), while the app connects to the node's **storage server** over QUIC/HTTPS
+> (`DEVNET_OMQ_PORT` / `DEVNET_HTTP_PORT`). The `QNET`/`P2P`/`ZMQ` columns aren't used.
+
+> **Stable pubkey:** the compose mounts no volume for the data dir, so a fresh `--build`/recreate
+> regenerates the seed keys and `DEVNET_PUBKEY` drifts (it's stable across `restart` of the _same_
+> container). For a paste-once config, add a volume for the cached-devnet data dir; otherwise
+> re-read the pubkey after each recreate. (The `Pubkey` column is the node's `service_node_pubkey`,
+> which is the ed25519 key on current oxen — if the app can't connect to the seed, re-check this.)
+
+## 4. Environment
+
+Add to `.env` (see `.env.sample`):
+
+```bash
+NETWORK_TARGET=devnet
+DEVNET_PUBKEY=<Pubkey column>
+DEVNET_IP=<LISTEN_IP>
+DEVNET_RPC_PORT=1280     # IP:RPC       (seeder)
+DEVNET_HTTP_PORT=1300    # Storage HTTPS (app)
+DEVNET_OMQ_PORT=1305     # Storage OMQ   (app)
+```
+
+`NETWORK_TARGET` drives both the app (`capabilities_ios.ts` injects `serviceNetwork`/`devnet*` into
+the app's launch-arg env) and the seeder (`getNetworkTarget` targets
+`http://$DEVNET_IP:$DEVNET_RPC_PORT`). If any `DEVNET_*` value is missing/invalid, the run fails
+fast with a message naming what's wrong.
+
+## 4b. (Optional) local file server
+
+The file server comes up **with the devnet** — the `docker compose up --build` from step 2 also
+starts a `sesh-net-fileserver` container (self-contained: postgres + nginx + uwsgi) published on
+`:8000`, with a deterministic key so its pubkeys are stable. Pointing the app at it speeds the
+media tests (attachments, avatars).
+
+Grab its **X25519** pubkey from the logs — LibSession-Util consumes the custom file-server pubkey
+directly as an x25519 key (`x25519_pubkey::from_hex`, no ed25519 conversion), so pass the X25519 one:
+
+```bash
+docker compose logs fileserver | grep -i pubkey
+#   File server Ed25519 pubkey: 23bc…
+#   which is X25519 pubkey:     51bd…       <- use this one
+```
+
+Then add to `.env`:
+
+```bash
+FILE_SERVER_URL=http://<DEVNET_IP>:8000     # reached by the exit snode, so use the devnet IP
+FILE_SERVER_PUBKEY=<X25519 pubkey>          # omit to use the app's default file-server pubkey
+```
+
+Notes:
+
+- The app reaches the file server via an **onion request through the devnet snodes**, so
+  `FILE_SERVER_URL` must be reachable **from the snodes** (i.e. the OrbStack VM) — the devnet
+  `DEVNET_IP:8000` satisfies that (and macOS too).
+- Leave `FILE_SERVER_URL` unset to keep using the production file server.
+- **Troubleshooting** — if the file server logs `Failed to decrypt onion request (tried 1 pubkeys)`
+  (media uploads fail): the request is reaching the server but the client encrypted to a key the
+  server can't match. Check, in order: (1) the value is the **X25519** pubkey (LibSession-Util uses
+  it directly as the x25519 key — the ed25519 will not work), not the ed25519; (2) the app actually
+  picked it up — Developer Settings ▸ File Server in the sim should show your `customFileServerPubkey`;
+  (3) a clean app state (uninstall/recreate sims) so a previously-cached custom file server isn't
+  stale. Note: the app's own `FileServer.edPublicKey`/`x25519PublicKey` Swift helpers treat this
+  field as ed25519, which conflicts with libsession consuming it as x25519 — a Session_iOS
+  inconsistency worth raising if the two paths ever both matter.
+
+## 5. Run
+
+```bash
+pnpm test-ios-parallel --network devnet --grep '@ios @high-risk'   # flag overrides .env
+# or, with NETWORK_TARGET=devnet in .env:
+pnpm test-ios --grep '@ios @high-risk'
+```
+
+## Validation checklist
+
+After `docker compose up`, confirm before trusting a run:
+
+1. From macOS the seed responds:
+   ```bash
+   curl -s http://$DEVNET_IP:1280/json_rpc -d '{"method":"get_service_nodes"}'
+   ```
+2. In the printed node table, the advertised IP column is `$DEVNET_IP` — **not** a `127.x`/`172.x`
+   address (if it is, `LISTEN_IP` was wrong and the client won't be able to reach the snodes).
+3. (Optional) the same `curl` from a booted simulator — but #1 passing is normally sufficient since
+   simulators share the Mac's routes.
+
+## CI
+
+Nothing in CI changes when you set this up locally. `ios-regression.yml` exposes a `NETWORK_TARGET`
+input (`devnet`/`testnet`/`mainnet`) and reads the devnet connection details from repo-level Actions
+variables (`DEVNET_PUBKEY`, `DEVNET_IP`, `DEVNET_HTTP_PORT`, `DEVNET_OMQ_PORT`). The macOS runner
+reaches a **Linux-hosted** devnet over the network (Tailscale/LAN) — the only per-environment
+difference is the IP value, which is already env-driven.
+
+## Notes & gotchas
+
+- **One devnet per host** — `network_mode: host` means only one can run at a time on a machine.
+- **Self-signed HTTPS storage** (the readiness probe uses `curl --insecure`). Fine for Session's
+  x25519-keyed snode connections; worth a one-time confirmation the iOS client accepts it on devnet.
+- **File server is optional** — see [4b](#4b-optional-local-file-server). Set `FILE_SERVER_URL`
+  (+ `FILE_SERVER_PUBKEY`) to route media through the local file server; leave unset to use the
+  production one.
+- **Ignore `docker-compose.yml.wip`** at the Sesh-Net-Docker root — it's a separate, half-finished
+  Postgres+fileserver stack. Use the `sesh-net/` compose (this guide) and the `file-server/` flow.

--- a/run/test/utils/capabilities_ios.ts
+++ b/run/test/utils/capabilities_ios.ts
@@ -30,9 +30,17 @@ export const IOS_PRO_CONTEXT: IOSTestContext = { sessionProEnabled: 'true' };
 
 export type IosServiceNetwork = 'devnet' | 'mainnet' | 'testnet';
 
+// The devnet seed node is a single node that plays two roles with THREE different ports, because
+// the app and the qa-seeder talk to different services on it:
+//   - rpcPort  (oxend RPC, HTTP)   -> the SEEDER hits `http://ip:rpcPort/json_rpc` (get_service_nodes)
+//   - httpPort (storage HTTPS)     -> the APP's devnetHttpPort (Snode.httpsPort)
+//   - omqPort  (storage OMQ/QUIC)  -> the APP's devnetOmqPort  (Snode.omqPort, the QUIC connection)
+// On the Sesh-Net-Docker devnet these map to the `IP:RPC`, `Storage HTTPS` and `Storage OMQ`
+// columns of the seed node's row (e.g. 1280 / 1300 / 1305 for the `oxend@1280` node).
 export type IosDevnetConfig = {
   pubkey: string;
   ip: string;
+  rpcPort: string;
   httpPort: string;
   omqPort: string;
 };
@@ -48,42 +56,51 @@ export function getIosServiceNetwork(): IosServiceNetwork {
 }
 
 /**
- * Devnet connection details for the iOS app, read from the environment. Mirrors the validation the
- * app itself does, and throws (listing what's missing/invalid) so a misconfigured devnet run fails
- * fast here rather than the app silently falling back to testnet.
+ * Devnet connection details, read from the environment. Mirrors the validation the app itself does,
+ * and throws (listing what's missing/invalid) so a misconfigured devnet run fails fast here rather
+ * than the app silently falling back to testnet.
  */
 export function getIosDevnetConfig(): IosDevnetConfig {
   const pubkey = (process.env.DEVNET_PUBKEY ?? '').trim();
   const ip = (process.env.DEVNET_IP ?? '').trim();
+  const rpcPort = (process.env.DEVNET_RPC_PORT ?? '').trim();
   const httpPort = (process.env.DEVNET_HTTP_PORT ?? '').trim();
   const omqPort = (process.env.DEVNET_OMQ_PORT ?? '').trim();
 
+  const isPort = (p: string) => /^\d{1,5}$/.test(p) && Number(p) <= 65535;
+
   const errors: string[] = [];
   if (!/^[0-9a-fA-F]{64}$/.test(pubkey)) {
-    errors.push('DEVNET_PUBKEY must be a 64-character hex string');
+    errors.push('DEVNET_PUBKEY must be a 64-character hex string (seed node ed25519 pubkey)');
   }
   const octets = ip.split('.');
   if (octets.length !== 4 || !octets.every(o => /^\d{1,3}$/.test(o) && Number(o) <= 255)) {
     errors.push('DEVNET_IP must be an IPv4 address like 10.0.0.1');
   }
-  if (!/^\d{1,5}$/.test(httpPort) || Number(httpPort) > 65535) {
-    errors.push('DEVNET_HTTP_PORT must be a number between 0 and 65535');
+  if (!isPort(rpcPort)) {
+    errors.push('DEVNET_RPC_PORT must be a number 0-65535 (seed oxend RPC, for the seeder)');
   }
-  if (!/^\d{1,5}$/.test(omqPort) || Number(omqPort) > 65535) {
-    errors.push('DEVNET_OMQ_PORT must be a number between 0 and 65535');
+  if (!isPort(httpPort)) {
+    errors.push('DEVNET_HTTP_PORT must be a number 0-65535 (seed storage HTTPS, for the app)');
+  }
+  if (!isPort(omqPort)) {
+    errors.push('DEVNET_OMQ_PORT must be a number 0-65535 (seed storage OMQ/QUIC, for the app)');
   }
   if (errors.length > 0) {
     throw new Error(
       `NETWORK_TARGET=devnet requires valid devnet env vars:\n  - ${errors.join('\n  - ')}`
     );
   }
-  return { pubkey, ip, httpPort, omqPort };
+  return { pubkey, ip, rpcPort, httpPort, omqPort };
 }
 
-/** Seed-node URL the seeder should use for devnet (same devnet the app connects to). */
+/**
+ * Seed URL the SEEDER (qa-seeder) uses for devnet — the seed node's oxend RPC (`/json_rpc`
+ * get_service_nodes), which is a different port from the storage ports the app connects to.
+ */
 export function getIosDevnetSeedUrl(): `http://${string}` {
-  const { ip, httpPort } = getIosDevnetConfig();
-  return `http://${ip}:${httpPort}`;
+  const { ip, rpcPort } = getIosDevnetConfig();
+  return `http://${ip}:${rpcPort}`;
 }
 
 /** Extra processArguments.env keys that point the app at the selected service network. */
@@ -105,16 +122,40 @@ function buildServiceNetworkEnv(): Record<string, string> {
   };
 }
 
+/**
+ * Optional custom file server (e.g. a local Sesh-Net-Docker file server). When `FILE_SERVER_URL`
+ * is set, the app is pointed at it via `customFileServerUrl` (+ `customFileServerPubkey`), which
+ * speeds up media tests. `FILE_SERVER_PUBKEY` is the file server's **X25519** pubkey: LibSession-Util
+ * consumes it directly as `x25519_pubkey::from_hex(...)` (its built-in default `da21…` is an X25519
+ * key) — it does NOT convert from ed25519, and the app passes this value to libsession raw. If
+ * omitted the app falls back to its default file server pubkey. Independent of the network target —
+ * but only really useful alongside a devnet.
+ */
+function buildCustomFileServerEnv(): Record<string, string> {
+  const url = (process.env.FILE_SERVER_URL ?? '').trim();
+  if (!url) {
+    return {};
+  }
+  const pubkey = (process.env.FILE_SERVER_PUBKEY ?? '').trim();
+  if (pubkey && !/^[0-9a-fA-F]{64}$/.test(pubkey)) {
+    throw new Error('FILE_SERVER_PUBKEY must be a 64-character hex string (X25519 pubkey)');
+  }
+  return {
+    customFileServerUrl: url,
+    ...(pubkey ? { customFileServerPubkey: pubkey } : {}),
+  };
+}
+
 // Resolved lazily and memoised on first iOS capability build (NOT at module load): this file is
 // also imported on Android runs, where NETWORK_TARGET may be `devnet` — we must not try to read
-// (and throw on) the iOS-only DEVNET_* vars there. getIosCapabilities is iOS-only, so validation
-// happens exactly when/where it's relevant.
-let serviceNetworkEnvCache: Record<string, string> | undefined;
-function getServiceNetworkEnv(): Record<string, string> {
-  if (serviceNetworkEnvCache === undefined) {
-    serviceNetworkEnvCache = buildServiceNetworkEnv();
+// (and throw on) the iOS-only DEVNET_*/FILE_SERVER_* vars there. getIosCapabilities is iOS-only, so
+// validation happens exactly when/where it's relevant.
+let appEnvOverridesCache: Record<string, string> | undefined;
+function getAppEnvOverrides(): Record<string, string> {
+  if (appEnvOverridesCache === undefined) {
+    appEnvOverridesCache = { ...buildServiceNetworkEnv(), ...buildCustomFileServerEnv() };
   }
-  return serviceNetworkEnvCache;
+  return appEnvOverridesCache;
 }
 
 const iosPathPrefix = process.env.IOS_APP_PATH_PREFIX;
@@ -261,9 +302,9 @@ export function getIosCapabilities(
   }
 
   // Rebuild the processArguments block with merged env vars.
-  // The service-network env (mainnet/testnet/devnet selection) is layered under per-test customEnv.
+  // App env overrides (network selection + optional custom file server) sit under per-test customEnv.
   caps['appium:processArguments'] = {
-    env: { ...baseEnv, ...getServiceNetworkEnv(), ...customEnv },
+    env: { ...baseEnv, ...getAppEnvOverrides(), ...customEnv },
   };
 
   return {

--- a/run/types/DeviceWrapper.ts
+++ b/run/types/DeviceWrapper.ts
@@ -1340,6 +1340,25 @@ export class DeviceWrapper {
   }
 
   /**
+   * Fast "element is gone" check: polls until the element is absent, confirmed by 3 consecutive
+   * misses (a built-in debounce against flicker/reappear), and returns as soon as that holds —
+   * so it's near-instant when the element is already gone. Unlike `hasElementBeenDeleted`, it does
+   * NOT require the element to be present first, so it's safe for "already gone" cases.
+   *
+   * Use this instead of `verifyElementNotPresent` ONLY when the intent is "this UI element is gone
+   * after an action". Do NOT use it to prove "a message/content never arrives over a window"
+   * (absent-now != absent-later there) — keep `verifyElementNotPresent` for those.
+   */
+  public async waitForElementToBeGone(
+    args: { text?: string; maxWait?: number } & (LocatorsInterface | StrategyExtractionObj)
+  ): Promise<void> {
+    const { locator, description } = this.resolveLocator(args);
+    const maxWait = args.maxWait ?? 5_000;
+    await this.waitForElementToDisappear(locator, maxWait, args.text);
+    this.log(`Confirmed element gone: ${description}`);
+  }
+
+  /**
    * Waits for an element to be deleted from the screen. The element must exist initially.
    *
    * @param args - Locator (LocatorsInterface or StrategyExtractionObj) with optional properties


### PR DESCRIPTION
Build on the devnet support from #108 to let the iOS suite target a local file server (e.g. the Sesh-Net-Docker one) and fix the devnet seed-node port mapping.
- Custom file server: FILE_SERVER_URL (+ optional FILE_SERVER_PUBKEY, the server's X25519 key) are injected as the app's customFileServerUrl / customFileServerPubkey launch args, so media-test uploads/downloads can use a local file server. Unset = the app's default file server.
- Devnet seed ports split to match how the node is actually used: DEVNET_RPC_PORT (the seed oxend /json_rpc, used by the qa-seeder) is now distinct from DEVNET_HTTP_PORT (storage HTTPS) and DEVNET_OMQ_PORT (storage OMQ/QUIC), which the app connects to. Previously a single HTTP port conflated the two.
- App env overrides (service network + custom file server) are resolved lazily and memoised, so importing capabilities_ios on Android runs never touches the iOS-only DEVNET_*/FILE_SERVER_* vars.
- ios-regression.yml passes DEVNET_RPC_PORT; .env.sample, CLAUDE.md and README document the new vars; docs/local-devnet-ios.md is a full guide to running the devnet + file server locally (incl. OrbStack on the same machine as the sims).