### PR TITLE
Performance improvements in light of new devnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ playwright.config.js
 test-results/
 output/
 dist/
+build/
 avd/*
 .eslintcache
 test-results.csv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,31 @@ Locally `DEVICES_PER_TEST_COUNT` defaults to 4 and the largest specs need 4 devi
 (`countOfDevicesNeeded: 4`), so **4 sims covers every iOS spec** at 1 worker. XCUITest
 boots a sim by UDID automatically at session start — no manual boot.
 
+`global-setup.ts` prepares the pool the run will use (`workers × DEVICES_PER_TEST_COUNT`) before any
+test starts — on CI as well as locally. It **pre-boots** the simulators, **pre-installs** the app,
+and starts one long-lived **WebDriverAgent** per simulator, passing the live ports to the workers via
+`WDA_REUSE_PORTS`. Each of those is otherwise paid inside a test: boot and app install land on
+whichever test touches a device first (~150s for 3 cold devices), and WDA is installed *and launched
+per session* behind a process-wide lock, serialising session startup at ~4.3s per device.
+
+With `appium:webDriverAgentUrl` pointing at a running WDA the driver's launch collapses to one
+`/status` call, so both the install and the serialisation disappear (~8s saved on a 3-device test).
+All of it is best-effort: anything that fails falls back to the driver doing it itself. Already-warm
+simulators make the whole step a no-op, so back-to-back runs skip it.
+
+> Note this reverses a CI choice — the workflow's "Start simulators" step is disabled with a comment
+> that letting Appium boot was more reliable. Pre-booting is a prerequisite for launching WDA
+> (`simctl launch` needs a booted device) and uses `simctl bootstatus -b`, which waits for boot to
+> genuinely finish. If CI becomes flaky at startup, this block is the first thing to revert.
+
+> **Stay at 1 worker locally.** Each booted simulator spawns **~280 host processes** — 6 sims took a
+> 14-core Mac to a load average of ~500 and caused specs to fail on timeouts that had nothing to do
+> with the app (they passed immediately at 1 worker). Parallelism *works* (workers get correctly
+> offset device pools), but the host, not the harness, is the bottleneck: throughput barely improves
+> and false failures become indistinguishable from real ones. `global-setup.ts` prints a warning
+> when `workers > 1`. If you must parallelise, use 2 workers × 2 devices (same total sim count)
+> restricted to `@1-devices`/`@2-devices` specs.
+
 ## Running tests
 
 Scripts (see `package.json`); `--grep` filters on the auto-generated test name.

--- a/README.md
+++ b/README.md
@@ -97,10 +97,16 @@ _TESTING=1                           # Skip printing appium/wdio logs
 PLAYWRIGHT_RETRIES_COUNT=0           # Test retry attempts
 PLAYWRIGHT_REPEAT_COUNT=0            # Successful test repeat count
 PLAYWRIGHT_WORKERS_COUNT_ANDROID=1   # Parallel test workers for Android (selected via PLATFORM)
-PLAYWRIGHT_WORKERS_COUNT_IOS=1       # Parallel test workers for iOS (selected via PLATFORM)
+PLAYWRIGHT_WORKERS_COUNT_IOS=1       # Parallel test workers for iOS (selected via PLATFORM, keep at 1 locally — see note below)
 PLAYWRIGHT_WORKERS_COUNT_DESKTOP=1   # Parallel test workers for desktop (selected via PLATFORM)
 CI=0                                 # Set to 1 to simulate CI (mostly for Allure reporting)
 ALLURE_ENABLED=false                 # Set to 'true' to generate Allure reports (in conjunction with CI=1)
 UPDATE_BASELINES=true                # Auto-save new screenshot baselines if unavailable
 SOGS_ADMIN_SEED='word1 word2...'     # 13-word recovery phrase of an account that's an admin in the testing SOGS.
 ```
+
+> **Keep `PLAYWRIGHT_WORKERS_COUNT=1` for local runs.** Each booted simulator spawns roughly 280
+> host processes, so running multiple workers (and therefore multiple simulator pools) saturates the
+> machine — on a 14-core Mac, 6 simulators drove the load average to ~500 and made specs fail on
+> timeouts unrelated to the app; the same specs passed immediately at 1 worker. The suite warns you
+> when more than one worker is configured.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ UPDATE_BASELINES=true                # Auto-save new screenshot baselines if una
 SOGS_ADMIN_SEED='word1 word2...'     # 13-word recovery phrase of an account that's an admin in the testing SOGS.
 ```
 
-> **Keep `PLAYWRIGHT_WORKERS_COUNT=1` for local runs.** Each booted simulator spawns roughly 280
+> **Keep `PLAYWRIGHT_WORKERS_COUNT_IOS=1` for local runs.** Each booted simulator spawns roughly 280
 > host processes, so running multiple workers (and therefore multiple simulator pools) saturates the
 > machine — on a 14-core Mac, 6 simulators drove the load average to ~500 and made specs fail on
 > timeouts unrelated to the app; the same specs passed immediately at 1 worker. The suite warns you

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -1,7 +1,32 @@
 import { FullConfig } from '@playwright/test';
 
+import { getDevicesPerTestCount, getWorkersCount } from './run/test/utils/binaries';
 import { getNetworkTarget } from './run/test/utils/devnet';
 import { SupportedPlatformsType } from './run/test/utils/open_app';
+import { ensureWdaBuilt } from './scripts/build_wda';
+import {
+  bootSimulatorPool,
+  installAppOnSimulators,
+  launchWdaOnSimulators,
+  resolveRunSimulators,
+} from './scripts/ios_shared';
+
+/**
+ * Does this run target iOS? `PLATFORM` is set on CI and by run_ios_parallel; otherwise fall back to
+ * looking for the `@ios` tag filter that every iOS run greps on (see run/types/sessionIt.ts).
+ *
+ * The tag is read from `process.argv` rather than `config.grep`, because Playwright applies a CLI
+ * `--grep` as a separate filter and leaves `config.grep` as its match-everything default.
+ *
+ * Conservative by design: when we can't tell (e.g. running a spec file directly with no tag
+ * filter), we skip pre-booting and leave Appium to boot on demand, exactly as before.
+ */
+function isIosRun(platform: string | undefined): boolean {
+  if (platform) {
+    return platform === 'ios';
+  }
+  return process.argv.slice(2).some(arg => /@ios/i.test(arg));
+}
 
 export default async function globalSetup(_config: FullConfig) {
   const platform = process.env.PLATFORM as SupportedPlatformsType | undefined;
@@ -12,5 +37,71 @@ export default async function globalSetup(_config: FullConfig) {
   } else {
     // The CI knows the platform variable, this is for local development
     console.log('No PLATFORM variable set, network validation will happen on a per-test level');
+  }
+
+  // Applies to CI as well as local runs. NOTE: CI previously left simulator booting entirely to
+  // Appium (the workflow's "Start simulators" step is disabled with a comment saying that was more
+  // reliable). Pre-booting here is a prerequisite for starting WebDriverAgent below — `simctl
+  // launch` needs a booted device — and uses `simctl bootstatus -b`, which waits for boot to
+  // actually complete rather than boot-then-sleep. If CI turns flaky at startup, this block is the
+  // first thing to revert; it is purely an optimisation and the driver can do all of it itself.
+  if (isIosRun(platform)) {
+    const isCI = process.env.CI === '1';
+    const workers = getWorkersCount();
+    const devicesPerWorker = getDevicesPerTestCount();
+
+    // Resolved from .env locally and ci-simulators.json on CI, each carrying its wdaLocalPort.
+    const available = resolveRunSimulators();
+    // Each booted simulator costs the host ~280 processes, so booting more than the run can use
+    // would slow it down rather than speed it up. Prepare exactly the pool the workers will
+    // allocate from (see openiOSApp in open_app.ts for the offsetting).
+    const pool = available.slice(0, Math.min(workers * devicesPerWorker, available.length));
+    await bootSimulatorPool(pool.map(sim => sim.udid));
+
+    // Install the app up front too: on a simulator that doesn't already have it, Appium's install
+    // happens inside the first session and dominates that test (~150s for 3 devices, vs ~17s warm).
+    // `simctl install` is an upsert, so this is a no-op once the app is present and unchanged.
+    if (process.env.IOS_APP_PATH_PREFIX) {
+      await installAppOnSimulators(
+        pool.map(sim => sim.udid),
+        process.env.IOS_APP_PATH_PREFIX
+      );
+    }
+
+    // Start one long-lived WebDriverAgent per simulator and tell the workers (via env, which they
+    // inherit when Playwright spawns them after this hook) which ports to attach to. Saves ~8s on a
+    // 3-device test by removing the per-session WDA install and its cross-device serialisation.
+    // Ports that don't come up are simply omitted, and those devices fall back to the driver's own
+    // WDA handling — see getIosCapabilities.
+    //
+    // Building WDA here (rather than only in run_ios_parallel) is what makes this work on CI, whose
+    // runners are ephemeral and have no prebuilt runner. It is a one-off cost per job that replaces
+    // the driver's per-session xcodebuild.
+    try {
+      const wdaPath = ensureWdaBuilt();
+      const readyPorts = await launchWdaOnSimulators(
+        pool.map(sim => ({ udid: sim.udid, port: sim.wdaPort })),
+        wdaPath
+      );
+      if (readyPorts.length > 0) {
+        process.env.WDA_REUSE_PORTS = readyPorts.join(',');
+      }
+    } catch (error: unknown) {
+      // Never block a run on this: without it the driver builds and launches WDA itself, as before.
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(
+        `Could not prepare WebDriverAgent (falling back to the driver's own): ${message}`
+      );
+    }
+
+    if (!isCI && workers > 1) {
+      console.warn(
+        `\n⚠️  Running ${workers} Playwright workers x ${devicesPerWorker} device(s) = ` +
+          `${workers * devicesPerWorker} simulators.\n` +
+          `   Each booted simulator spawns ~280 processes, so multiple workers can saturate the\n` +
+          `   host and cause tests to fail on timeouts that have nothing to do with the app.\n` +
+          `   If you see unexplained "element not found" failures, re-run with 1 worker to confirm.\n`
+      );
+    }
   }
 }

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -47,7 +47,7 @@ export default async function globalSetup(_config: FullConfig) {
   // first thing to revert; it is purely an optimisation and the driver can do all of it itself.
   if (isIosRun(platform)) {
     const isCI = process.env.CI === '1';
-    const workers = getWorkersCount();
+    const workers = getWorkersCount('ios');
     const devicesPerWorker = getDevicesPerTestCount();
 
     // Resolved from .env locally and ci-simulators.json on CI, each carrying its wdaLocalPort.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "cleanup-simulators": "npx ts-node scripts/cleanup_ios_simulators.ts",
     "create-simulators": "pnpm cleanup-simulators && npx ts-node scripts/create_ios_simulators.ts",
+    "build-wda": "npx ts-node scripts/build_wda.ts",
     "recover-emulators": "npx ts-node scripts/emulator_health.ts",
     "setup-virtual-scene": "npx ts-node scripts/setup_virtual_scene.ts",
     "lint": "pnpm prettier . --write --cache && pnpm eslint . --cache ",

--- a/run/test/specs/mobile/community_emoji_react.spec.ts
+++ b/run/test/specs/mobile/community_emoji_react.spec.ts
@@ -48,7 +48,7 @@ async function sendEmojiReactionCommunity(platform: SupportedPlatformsType, test
     await bob1.longPressMessage(new MessageBody(bob1, message));
     await bob1.clickOnElementAll(new FirstEmojiReact(bob1));
     // Verify long press menu disappeared (so next found emoji is in convo and not in react bar)
-    await bob1.verifyElementNotPresent({
+    await bob1.waitForElementToBeGone({
       strategy: 'accessibility id',
       selector: 'Reply to message',
     });

--- a/run/test/specs/mobile/community_requests_off.spec.ts
+++ b/run/test/specs/mobile/community_requests_off.spec.ts
@@ -5,7 +5,6 @@ import { communities } from '../../../constants/community';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
 import { CommunityMessageAuthor, UPMMessageButton } from '../../locators/conversation';
-import { sleepFor } from '../../utils';
 import { joinCommunity } from '../../utils/community';
 import { newUser } from '../../utils/create_account';
 import { closeApp, openAppTwoDevices, SupportedPlatformsType } from '../../utils/open_app';
@@ -45,8 +44,6 @@ async function blindedMessageRequests(platform: SupportedPlatformsType, testInfo
   );
   await device1.clickOnElementAll(new CommunityMessageAuthor(device1, message));
   await test.step(`Verify the 'Message' button in the User Profile Modal is disabled`, async () => {
-    // brief sleep to let the UI settle
-    await sleepFor(1000);
     const messageButton = await device1.waitForTextElementToBePresent(
       new UPMMessageButton(device1)
     );

--- a/run/test/specs/mobile/community_requests_on.spec.ts
+++ b/run/test/specs/mobile/community_requests_on.spec.ts
@@ -67,8 +67,6 @@ async function blindedMessageRequests(platform: SupportedPlatformsType, testInfo
   await test.step(
     TestSteps.SEND.MESSAGE(bob.userName, communities.testCommunity.name),
     async () => {
-      // brief sleep to let the UI settle
-      await sleepFor(1000);
       await device2.sendMessage(message);
       await device2.navigateBack();
     }

--- a/run/test/specs/mobile/community_tests_join.spec.ts
+++ b/run/test/specs/mobile/community_tests_join.spec.ts
@@ -5,7 +5,6 @@ import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
 import { ConversationItem } from '../../locators/home';
 import { open_Alice2 } from '../../state_builder';
-import { sleepFor } from '../../utils';
 import { joinCommunity } from '../../utils/community';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
 
@@ -32,7 +31,6 @@ async function joinCommunityTest(platform: SupportedPlatformsType, testInfo: Tes
   const testMessage = `Test message + ${new Date().getTime()}`;
   await test.step(TestSteps.NEW_CONVERSATION.JOIN_COMMUNITY, async () => {
     await joinCommunity(alice1, communities.testCommunity.link, communities.testCommunity.name);
-    await sleepFor(5000);
   });
   await test.step(
     TestSteps.SEND.MESSAGE(alice.userName, communities.testCommunity.name),

--- a/run/test/specs/mobile/disappear_after_read.spec.ts
+++ b/run/test/specs/mobile/disappear_after_read.spec.ts
@@ -3,11 +3,15 @@ import { test, type TestInfo } from '@playwright/test';
 import { tStripped } from '../../../localizer/lib';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
-import { DISAPPEARING_TIMES, DisappearModes } from '../../../types/testing';
+import { DisappearModes } from '../../../types/testing';
 import { MessageBody } from '../../locators/conversation';
 import { open_Alice1_Bob1_friends } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappear after read',
@@ -36,8 +40,8 @@ async function disappearAfterRead(platform: SupportedPlatformsType, testInfo: Te
   const testMessage = 'Checking disappear after read is working';
   const mode: DisappearModes = 'read';
   // TODO: Consider refactoring DISAPPEARING_TIMES to include ms values
-  const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
-  const maxWait = 35_000; // 30s plus buffer
+  const time = getDisappearingTestTime();
+  const { expectedDuration, maxWait } = getDisappearingTestTiming();
   let sentTimestamp: number;
   // Click conversation options menu (three dots)
   await test.step(TestSteps.DISAPPEARING_MESSAGES.SET(time), async () => {
@@ -69,6 +73,7 @@ async function disappearAfterRead(platform: SupportedPlatformsType, testInfo: Te
         device.hasElementDisappeared({
           ...new MessageBody(device, testMessage).build(),
           maxWait,
+          expectedDuration,
           actualStartTime: sentTimestamp,
         })
       )

--- a/run/test/specs/mobile/disappear_after_send.spec.ts
+++ b/run/test/specs/mobile/disappear_after_send.spec.ts
@@ -2,11 +2,15 @@ import type { TestInfo } from '@playwright/test';
 
 import { tStripped } from '../../../localizer/lib';
 import { bothPlatformsIt } from '../../../types/sessionIt';
-import { DisappearActions, DISAPPEARING_TIMES, DisappearModes } from '../../../types/testing';
+import { DisappearActions, DisappearModes } from '../../../types/testing';
 import { MessageBody } from '../../locators/conversation';
 import { open_Alice1_Bob1_friends } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappear after send',
@@ -32,8 +36,8 @@ async function disappearAfterSend(platform: SupportedPlatformsType, testInfo: Te
   const mode: DisappearModes = 'send';
   const testMessage = `Checking disappear after ${mode} is working`;
   const controlMode: DisappearActions = 'sent';
-  const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
-  const maxWait = 35_000; // 30s plus buffer
+  const time = getDisappearingTestTime();
+  const { expectedDuration, maxWait } = getDisappearingTestTiming();
   // Select disappearing messages option
   await setDisappearingMessage(alice1, ['1:1', `Disappear after ${mode} option`, time]);
   // Check control messages on both devices
@@ -57,6 +61,7 @@ async function disappearAfterSend(platform: SupportedPlatformsType, testInfo: Te
       device.hasElementDisappeared({
         ...new MessageBody(device, testMessage).build(),
         maxWait,
+        expectedDuration,
         actualStartTime: sentTimestamp,
       })
     )

--- a/run/test/specs/mobile/disappear_after_send_groups.spec.ts
+++ b/run/test/specs/mobile/disappear_after_send_groups.spec.ts
@@ -3,11 +3,15 @@ import { test, type TestInfo } from '@playwright/test';
 import { tStripped } from '../../../localizer/lib';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
-import { DisappearActions, DISAPPEARING_TIMES } from '../../../types/testing';
+import { DisappearActions } from '../../../types/testing';
 import { MessageBody } from '../../locators/conversation';
 import { open_Alice1_Bob1_Charlie1_friends_group } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappear after send groups',
@@ -26,8 +30,8 @@ async function disappearAfterSendGroups(platform: SupportedPlatformsType, testIn
   const testGroupName = 'Disappear after send test';
   const testMessage = 'Testing disappear after sent in groups';
   const controlMode: DisappearActions = 'sent';
-  const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
-  const maxWait = 35_000; // 30s plus buffer
+  const time = getDisappearingTestTime();
+  const { expectedDuration, maxWait } = getDisappearingTestTiming();
   let sentTimestamp: number;
   const {
     devices: { alice1, bob1, charlie1 },
@@ -72,6 +76,7 @@ async function disappearAfterSendGroups(platform: SupportedPlatformsType, testIn
         device.hasElementDisappeared({
           ...new MessageBody(device, testMessage).build(),
           maxWait,
+          expectedDuration,
           actualStartTime: sentTimestamp,
         })
       )

--- a/run/test/specs/mobile/disappear_after_send_note_to_self.spec.ts
+++ b/run/test/specs/mobile/disappear_after_send_note_to_self.spec.ts
@@ -2,18 +2,21 @@ import { test, type TestInfo } from '@playwright/test';
 
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
-import { DisappearActions, DISAPPEARING_TIMES, USERNAME } from '../../../types/testing';
+import { DisappearActions, USERNAME } from '../../../types/testing';
 import { MessageBody } from '../../locators/conversation';
 import { PlusButton } from '../../locators/home';
 import { EnterAccountID, NewMessageOption, NextButton } from '../../locators/start_conversation';
-import { sleepFor } from '../../utils';
 import { newUser } from '../../utils/create_account';
 import {
   closeApp,
   openAppOnPlatformSingleDevice,
   SupportedPlatformsType,
 } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappear after send note to self',
@@ -31,8 +34,8 @@ bothPlatformsIt({
 async function disappearAfterSendNoteToSelf(platform: SupportedPlatformsType, testInfo: TestInfo) {
   const testMessage = `Testing disappearing messages in Note to Self`;
   const controlMode: DisappearActions = 'sent';
-  const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
-  const maxWait = 35_000; // 30s plus buffer
+  const time = getDisappearingTestTime();
+  const { expectedDuration, maxWait } = getDisappearingTestTiming();
   let sentTimestamp: number;
 
   const { device, alice } = await test.step(TestSteps.SETUP.NEW_USER, async () => {
@@ -51,7 +54,6 @@ async function disappearAfterSendNoteToSelf(platform: SupportedPlatformsType, te
   await test.step(TestSteps.DISAPPEARING_MESSAGES.SET(time), async () => {
     // Enable disappearing messages
     await setDisappearingMessage(device, ['Note to Self', 'Disappear after send option', time]);
-    await sleepFor(1000);
     await device.waitForControlMessageToBePresent(
       `You set messages to disappear ${time} after they have been ${controlMode}.`
     );
@@ -63,6 +65,7 @@ async function disappearAfterSendNoteToSelf(platform: SupportedPlatformsType, te
     await device.hasElementDisappeared({
       ...new MessageBody(device, testMessage).build(),
       maxWait,
+      expectedDuration,
       actualStartTime: sentTimestamp,
     });
   });

--- a/run/test/specs/mobile/disappear_after_send_off_1o1.spec.ts
+++ b/run/test/specs/mobile/disappear_after_send_off_1o1.spec.ts
@@ -2,7 +2,7 @@ import type { TestInfo } from '@playwright/test';
 
 import { tStripped } from '../../../localizer/lib';
 import { bothPlatformsIt } from '../../../types/sessionIt';
-import { DisappearActions, DISAPPEARING_TIMES, DisappearModes } from '../../../types/testing';
+import { DisappearActions, DisappearModes } from '../../../types/testing';
 import { ConversationSettings } from '../../locators/conversation';
 import {
   DisableDisappearingMessages,
@@ -13,7 +13,10 @@ import {
 import { ConversationItem } from '../../locators/home';
 import { open_Alice2_Bob1_friends } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappear after send off 1:1',
@@ -36,7 +39,7 @@ async function disappearAfterSendOff1o1(platform: SupportedPlatformsType, testIn
 
   const mode: DisappearModes = 'send';
   const controlMode: DisappearActions = 'sent';
-  const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
+  const time = getDisappearingTestTime();
   // Select disappearing messages option
   await setDisappearingMessage(alice1, ['1:1', `Disappear after ${mode} option`, time]);
   // Check control messages on both devices and sync to linked device
@@ -79,7 +82,7 @@ async function disappearAfterSendOff1o1(platform: SupportedPlatformsType, testIn
   // Check conversation subtitle?
   await Promise.all(
     [alice1, bob1, alice2].map(device =>
-      device.verifyElementNotPresent({
+      device.waitForElementToBeGone({
         ...new DisappearingMessagesSubtitle(device).build(),
         maxWait: 5_000,
       })

--- a/run/test/specs/mobile/disappear_after_send_off_1o1.spec.ts
+++ b/run/test/specs/mobile/disappear_after_send_off_1o1.spec.ts
@@ -2,7 +2,7 @@ import type { TestInfo } from '@playwright/test';
 
 import { tStripped } from '../../../localizer/lib';
 import { bothPlatformsIt } from '../../../types/sessionIt';
-import { DisappearActions, DisappearModes } from '../../../types/testing';
+import { DisappearActions, DISAPPEARING_TIMES, DisappearModes } from '../../../types/testing';
 import { ConversationSettings } from '../../locators/conversation';
 import {
   DisableDisappearingMessages,
@@ -10,13 +10,10 @@ import {
   DisappearingMessagesSubtitle,
   SetDisappearMessagesButton,
 } from '../../locators/disappearing_messages';
-import { ConversationItem } from '../../locators/home';
 import { open_Alice2_Bob1_friends } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import {
-  getDisappearingTestTime,
-  setDisappearingMessage,
-} from '../../utils/set_disappearing_messages';
+import { openConversation } from '../../utils/open_conversation';
+import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappear after send off 1:1',
@@ -39,7 +36,13 @@ async function disappearAfterSendOff1o1(platform: SupportedPlatformsType, testIn
 
   const mode: DisappearModes = 'send';
   const controlMode: DisappearActions = 'sent';
-  const time = getDisappearingTestTime();
+  // Deliberately not getDisappearingTestTime(): this spec never waits for anything to expire, it
+  // checks that turning the feature off syncs. A short timer is actively harmful here, because the
+  // "You set messages to disappear ..." control message is itself subject to the timer it announces
+  // — so the checks below race a countdown that starts the moment the setting is applied, and the
+  // devices furthest from the action (linked device, recipient) are the ones that lose. A timer that
+  // outlives the test removes the race without costing runtime.
+  const time = DISAPPEARING_TIMES.ONE_WEEK;
   // Select disappearing messages option
   await setDisappearingMessage(alice1, ['1:1', `Disappear after ${mode} option`, time]);
   // Check control messages on both devices and sync to linked device
@@ -56,9 +59,9 @@ async function disappearAfterSendOff1o1(platform: SupportedPlatformsType, testIn
         disappearing_messages_type: controlMode,
       })
     ),
-    alice2
-      .clickOnElementAll(new ConversationItem(alice2, bob.userName))
-      .then(() => alice2.waitForControlMessageToBePresent(setYouMsg)),
+    openConversation(alice2, bob.userName).then(() =>
+      alice2.waitForControlMessageToBePresent(setYouMsg)
+    ),
   ]);
 
   // Turn off disappearing messages on device 1

--- a/run/test/specs/mobile/disappearing_call.spec.ts
+++ b/run/test/specs/mobile/disappearing_call.spec.ts
@@ -3,14 +3,17 @@ import { test, type TestInfo } from '@playwright/test';
 import { tStripped } from '../../../localizer/lib';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsItSeparate } from '../../../types/sessionIt';
-import { DISAPPEARING_TIMES } from '../../../types/testing';
 import { CloseSettings } from '../../locators';
 import { CallButton, NotificationSwitch } from '../../locators/conversation';
 import { SettingsModalsEnableButton } from '../../locators/settings';
 import { open_Alice1_Bob1_friends } from '../../state_builder';
 import { sleepFor } from '../../utils';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsItSeparate({
   title: 'Disappearing call message 1:1',
@@ -33,9 +36,9 @@ bothPlatformsItSeparate({
   },
 });
 
-const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
+const time = getDisappearingTestTime();
 const timerType = 'Disappear after send option';
-const maxWait = 35_000; // 30s plus buffer
+const { expectedDuration, maxWait } = getDisappearingTestTiming();
 
 // TODO: abstract call logic into utils since they're reused in multiple tests
 async function disappearingCallMessage1o1Ios(platform: SupportedPlatformsType, testInfo: TestInfo) {
@@ -57,13 +60,14 @@ async function disappearingCallMessage1o1Ios(platform: SupportedPlatformsType, t
   await sleepFor(1_000);
   // Need to allow camera access
   await alice1.modalPopup({ strategy: 'accessibility id', selector: 'Allow' });
-  await sleepFor(10_000); // Wait a bit for the toggles to turn to TRUE
-  const aliceLocalNetworkSwitch = await alice1.waitForTextElementToBePresent({
-    strategy: 'accessibility id',
-    selector: 'Local Network Permission - Switch',
-  });
-  const aliceAttr = await alice1.getAttribute('value', aliceLocalNetworkSwitch.ELEMENT);
-  if (aliceAttr !== '1') {
+  // Poll the toggle until it flips to enabled rather than a fixed 10s wait — returns as soon as
+  // it's on (this auto-grant is a known-flaky Simulator behaviour).
+  const aliceLocalNetworkEnabled = await alice1.waitForElementValue(
+    { strategy: 'accessibility id', selector: 'Local Network Permission - Switch' },
+    '1',
+    10_000
+  );
+  if (!aliceLocalNetworkEnabled) {
     throw new Error(
       `Local Network Permission was not enabled automatically.
       This is a known Simulator bug that fails randomly with no pattern or fix.
@@ -103,6 +107,7 @@ async function disappearingCallMessage1o1Ios(platform: SupportedPlatformsType, t
       selector: 'Control message',
       text: callsYouCalled,
       maxWait,
+      expectedDuration,
       actualStartTime: callEndTimestamp,
     }),
     bob1.hasElementDisappeared({
@@ -110,6 +115,7 @@ async function disappearingCallMessage1o1Ios(platform: SupportedPlatformsType, t
       selector: 'Control message',
       text: callsMissedCallFrom,
       maxWait,
+      expectedDuration,
       actualStartTime: callEndTimestamp,
     }),
   ]);
@@ -170,6 +176,7 @@ async function disappearingCallMessage1o1Android(
       selector: 'network.loki.messenger:id/call_text_view',
       text: `You called ${bob.userName}`,
       maxWait,
+      expectedDuration,
       actualStartTime: callEndTimestamp,
     }),
     bob1.hasElementDisappeared({
@@ -177,6 +184,7 @@ async function disappearingCallMessage1o1Android(
       selector: 'network.loki.messenger:id/call_text_view',
       text: `Missed call from ${alice.userName}`,
       maxWait,
+      expectedDuration,
       actualStartTime: callEndTimestamp,
     }),
   ]);

--- a/run/test/specs/mobile/disappearing_community_invite.spec.ts
+++ b/run/test/specs/mobile/disappearing_community_invite.spec.ts
@@ -12,10 +12,13 @@ import {
 import { GroupMember } from '../../locators/groups';
 import { ConversationItem } from '../../locators/home';
 import { open_Alice1_Bob1_friends } from '../../state_builder';
-import { sleepFor } from '../../utils';
 import { joinCommunity } from '../../utils/community';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappearing community invite message 1:1',
@@ -31,9 +34,9 @@ bothPlatformsIt({
 });
 
 // Interacting with communities can be a bit fickle so we give this a bit more time
-const time = DISAPPEARING_TIMES.ONE_MINUTE;
+const time = getDisappearingTestTime(DISAPPEARING_TIMES.ONE_MINUTE);
 const timerType = 'Disappear after send option';
-const maxWait = 65_000; // 60s plus buffer
+const { expectedDuration, maxWait } = getDisappearingTestTiming(DISAPPEARING_TIMES.ONE_MINUTE);
 
 async function disappearingCommunityInviteMessage(
   platform: SupportedPlatformsType,
@@ -52,7 +55,6 @@ async function disappearingCommunityInviteMessage(
   await alice1.navigateBack();
   await joinCommunity(alice1, communities.testCommunity.link, communities.testCommunity.name);
   await alice1.clickOnElementAll(new ConversationSettings(alice1));
-  await sleepFor(1000);
   await alice1.clickOnElementAll(new InviteContactsMenuItem(alice1));
   await alice1.clickOnElementAll(new GroupMember(alice1).build(bob.userName));
   await alice1.clickOnElementAll(new CommunityInviteConfirmButton(alice1));
@@ -63,6 +65,7 @@ async function disappearingCommunityInviteMessage(
   await bob1.hasElementDisappeared({
     ...new CommunityInvitation(bob1).build(),
     maxWait,
+    expectedDuration,
     actualStartTime: communityInviteTimestamp,
   });
   // Leave Invite Contacts, Conversation Settings, Community, and open convo with Bob
@@ -71,6 +74,6 @@ async function disappearingCommunityInviteMessage(
   await alice1.onIOS().navigateBack(); // Android only needs to go back twice
   await alice1.clickOnElementAll(new ConversationItem(alice1, bob.userName));
   // At this point the invite should have disappeared already so we just check it's not there
-  await alice1.verifyElementNotPresent(new CommunityInvitation(alice1));
+  await alice1.waitForElementToBeGone(new CommunityInvitation(alice1));
   await closeApp(alice1, bob1);
 }

--- a/run/test/specs/mobile/disappearing_gif.spec.ts
+++ b/run/test/specs/mobile/disappearing_gif.spec.ts
@@ -5,7 +5,11 @@ import { DISAPPEARING_TIMES, USERNAME } from '../../../types/testing';
 import { MediaMessage } from '../../locators/conversation';
 import { open_Alice1_Bob1_friends } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappearing GIF message 1:1',
@@ -20,9 +24,12 @@ bothPlatformsIt({
 });
 
 // The timing with 30 seconds was a bit tight in terms of the attachment downloading and becoming visible
-const time = DISAPPEARING_TIMES.ONE_MINUTE;
+const time = getDisappearingTestTime(DISAPPEARING_TIMES.ONE_MINUTE);
 const initialMaxWait = 15_000; // GIFs could be large so give them a bit more time to be found
-const maxWait = 70_000; // 60s plus buffer
+const { expectedDuration, maxWait } = getDisappearingTestTiming(
+  DISAPPEARING_TIMES.ONE_MINUTE,
+  10_000
+);
 const timerType = 'Disappear after send option';
 
 async function disappearingGifMessage1o1(platform: SupportedPlatformsType, testInfo: TestInfo) {
@@ -42,6 +49,7 @@ async function disappearingGifMessage1o1(platform: SupportedPlatformsType, testI
         ...new MediaMessage(device).build(),
         initialMaxWait,
         maxWait,
+        expectedDuration,
         actualStartTime: sentTimestamp,
       })
     )

--- a/run/test/specs/mobile/disappearing_image.spec.ts
+++ b/run/test/specs/mobile/disappearing_image.spec.ts
@@ -1,11 +1,14 @@
 import type { TestInfo } from '@playwright/test';
 
 import { bothPlatformsIt } from '../../../types/sessionIt';
-import { DISAPPEARING_TIMES } from '../../../types/testing';
 import { MediaMessage, MessageBody } from '../../locators/conversation';
 import { open_Alice1_Bob1_friends } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappearing image message 1:1',
@@ -19,10 +22,10 @@ bothPlatformsIt({
   allureDescription: 'Verifies that an image disappears as expected in a 1:1 conversation',
 });
 
-const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
+const time = getDisappearingTestTime();
 const timerType = 'Disappear after send option';
 const testMessage = 'Testing disappearing messages for images';
-const maxWait = 35_000; // 30s plus buffer
+const { expectedDuration, maxWait } = getDisappearingTestTiming();
 
 async function disappearingImageMessage1o1(platform: SupportedPlatformsType, testInfo: TestInfo) {
   const {
@@ -42,6 +45,7 @@ async function disappearingImageMessage1o1(platform: SupportedPlatformsType, tes
         device.hasElementDisappeared({
           ...new MessageBody(device, testMessage).build(),
           maxWait,
+          expectedDuration,
           actualStartTime: sentTimestamp,
         })
       )
@@ -52,6 +56,7 @@ async function disappearingImageMessage1o1(platform: SupportedPlatformsType, tes
         device.hasElementDisappeared({
           ...new MediaMessage(device).build(),
           maxWait,
+          expectedDuration,
           actualStartTime: sentTimestamp,
         })
       )

--- a/run/test/specs/mobile/disappearing_link.spec.ts
+++ b/run/test/specs/mobile/disappearing_link.spec.ts
@@ -4,7 +4,6 @@ import { testLink } from '../../../constants';
 import { tStripped } from '../../../localizer/lib';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsItSeparate } from '../../../types/sessionIt';
-import { DISAPPEARING_TIMES } from '../../../types/testing';
 import { LinkPreview, LinkPreviewMessage } from '../../locators';
 import {
   MessageBody,
@@ -14,9 +13,12 @@ import {
 } from '../../locators/conversation';
 import { EnableLinkPreviewsModalButton } from '../../locators/global';
 import { open_Alice1_Bob1_friends } from '../../state_builder';
-import { sleepFor } from '../../utils';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsItSeparate({
   title: 'Disappearing link message 1:1',
@@ -35,9 +37,9 @@ bothPlatformsItSeparate({
   allureDescription: 'Verifies that a link preview disappears as expected in a 1:1 conversation',
 });
 
-const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
+const time = getDisappearingTestTime();
 const timerType = 'Disappear after read option';
-const maxWait = 35_000; // 30s plus buffer
+const { expectedDuration, maxWait } = getDisappearingTestTiming();
 let sentTimestamp: number;
 
 async function disappearingLinkMessage1o1Ios(platform: SupportedPlatformsType, testInfo: TestInfo) {
@@ -74,13 +76,14 @@ async function disappearingLinkMessage1o1Ios(platform: SupportedPlatformsType, t
     });
     sentTimestamp = Date.now();
   });
-  // Wait for 30 seconds to disappear
+  // Wait out the disappearing timer
   await test.step(TestSteps.VERIFY.MESSAGE_DISAPPEARED, async () => {
     await Promise.all(
       [alice1, bob1].map(device =>
         device.hasElementDisappeared({
           ...new MessageBody(device, testLink).build(),
           maxWait,
+          expectedDuration,
           actualStartTime: sentTimestamp,
         })
       )
@@ -117,8 +120,8 @@ async function disappearingLinkMessage1o1Android(
       );
     });
     await alice1.clickOnElementAll(new EnableLinkPreviewsModalButton(alice1));
-    // Preview takes a while to load
-    await sleepFor(5000);
+    // Wait for the link preview to load (poll rather than a fixed sleep)
+    await alice1.waitForTextElementToBePresent(new LinkPreview(alice1));
     await alice1.clickOnElementAll(new SendButton(alice1));
     await alice1.waitForTextElementToBePresent({
       ...new OutgoingMessageStatusSent(alice1).build(),
@@ -132,6 +135,7 @@ async function disappearingLinkMessage1o1Android(
         device.hasElementDisappeared({
           ...new LinkPreviewMessage(device).build(),
           maxWait,
+          expectedDuration,
           actualStartTime: sentTimestamp,
         })
       )

--- a/run/test/specs/mobile/disappearing_messages_follow_settings.spec.ts
+++ b/run/test/specs/mobile/disappearing_messages_follow_settings.spec.ts
@@ -2,7 +2,6 @@ import type { TestInfo } from '@playwright/test';
 
 import { tStripped } from '../../../localizer/lib';
 import { bothPlatformsIt } from '../../../types/sessionIt';
-import { DISAPPEARING_TIMES } from '../../../types/testing';
 import { MessageBody } from '../../locators/conversation';
 import {
   DisappearingMessagesSubtitle,
@@ -11,7 +10,11 @@ import {
 } from '../../locators/disappearing_messages';
 import { open_Alice1_Bob1_friends } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappearing messages follow setting 1:1',
@@ -26,9 +29,10 @@ bothPlatformsIt({
     'Verifies that Bob sees the Follow Setting banner when Alice sets disappearing messages in a 1:1 conversation, and that following applies the setting to both sides',
 });
 
-const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
+const time = getDisappearingTestTime();
 const timerType = 'Disappear after send option';
-const disappearMaxWait = 35_000; // 30s plus buffer
+const { expectedDuration: disappearExpected, maxWait: disappearMaxWait } =
+  getDisappearingTestTiming();
 
 async function disappearingMessagesFollowSetting1o1(
   platform: SupportedPlatformsType,
@@ -66,11 +70,13 @@ async function disappearingMessagesFollowSetting1o1(
         ...new MessageBody(device, aliceMsg).build(),
         actualStartTime: aliceTimestamp,
         maxWait: disappearMaxWait,
+        expectedDuration: disappearExpected,
       }),
       device.hasElementDisappeared({
         ...new MessageBody(device, bobMsg).build(),
         actualStartTime: bobTimestamp,
         maxWait: disappearMaxWait,
+        expectedDuration: disappearExpected,
       }),
     ])
   );

--- a/run/test/specs/mobile/disappearing_video.spec.ts
+++ b/run/test/specs/mobile/disappearing_video.spec.ts
@@ -5,7 +5,11 @@ import { DISAPPEARING_TIMES } from '../../../types/testing';
 import { MediaMessage, MessageBody } from '../../locators/conversation';
 import { open_Alice1_Bob1_friends } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappearing video message 1:1',
@@ -20,11 +24,14 @@ bothPlatformsIt({
 });
 
 // Sending and receiving the video can take a while so this is bumped to 60s
-const time = DISAPPEARING_TIMES.ONE_MINUTE;
+const time = getDisappearingTestTime(DISAPPEARING_TIMES.ONE_MINUTE);
 const timerType = 'Disappear after send option';
 const testMessage = 'Testing disappearing messages for videos';
 const initialMaxWait = 20_000; // Downloading the attachment can take a while
-const maxWait = 70_000; // 60s plus buffer
+const { expectedDuration, maxWait } = getDisappearingTestTiming(
+  DISAPPEARING_TIMES.ONE_MINUTE,
+  10_000
+);
 
 async function disappearingVideoMessage1o1(platform: SupportedPlatformsType, testInfo: TestInfo) {
   const {
@@ -50,6 +57,7 @@ async function disappearingVideoMessage1o1(platform: SupportedPlatformsType, tes
           ...new MessageBody(device, testMessage).build(),
           initialMaxWait,
           maxWait,
+          expectedDuration,
           actualStartTime: sentTimestamp,
         })
       )
@@ -61,6 +69,7 @@ async function disappearingVideoMessage1o1(platform: SupportedPlatformsType, tes
           ...new MediaMessage(device).build(),
           initialMaxWait,
           maxWait,
+          expectedDuration,
           actualStartTime: sentTimestamp,
         })
       )

--- a/run/test/specs/mobile/disappearing_voice.spec.ts
+++ b/run/test/specs/mobile/disappearing_voice.spec.ts
@@ -1,11 +1,14 @@
 import type { TestInfo } from '@playwright/test';
 
 import { bothPlatformsIt } from '../../../types/sessionIt';
-import { DISAPPEARING_TIMES } from '../../../types/testing';
 import { VoiceMessage } from '../../locators/conversation';
 import { open_Alice1_Bob1_friends } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappearing voice message 1:1',
@@ -19,9 +22,9 @@ bothPlatformsIt({
   allureDescription: 'Verifies that a voice message disappears as expected in a 1:1 conversation',
 });
 
-const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
+const time = getDisappearingTestTime();
 const timerType = 'Disappear after send option';
-const maxWait = 35_000; // 30s plus buffer
+const { expectedDuration, maxWait } = getDisappearingTestTiming();
 
 async function disappearingVoiceMessage1o1(platform: SupportedPlatformsType, testInfo: TestInfo) {
   const {
@@ -40,6 +43,7 @@ async function disappearingVoiceMessage1o1(platform: SupportedPlatformsType, tes
       device.hasElementDisappeared({
         ...new VoiceMessage(device).build(),
         maxWait,
+        expectedDuration,
         actualStartTime: sentTimestamp,
       })
     )

--- a/run/test/specs/mobile/group_disappearing_messages_gif.spec.ts
+++ b/run/test/specs/mobile/group_disappearing_messages_gif.spec.ts
@@ -5,7 +5,11 @@ import { DISAPPEARING_TIMES } from '../../../types/testing';
 import { MediaMessage } from '../../locators/conversation';
 import { open_Alice1_Bob1_Charlie1_friends_group } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappearing GIF to group',
@@ -20,10 +24,13 @@ bothPlatformsIt({
 });
 
 // The timing with 30 seconds was a bit tight in terms of the attachment downloading and becoming visible
-const time = DISAPPEARING_TIMES.ONE_MINUTE;
+const time = getDisappearingTestTime(DISAPPEARING_TIMES.ONE_MINUTE);
 const timerType = 'Disappear after send option';
 const initialMaxWait = 15_000; // Downloading the attachment can take a while
-const maxWait = 70_000; // 60s plus buffer
+const { expectedDuration, maxWait } = getDisappearingTestTiming(
+  DISAPPEARING_TIMES.ONE_MINUTE,
+  10_000
+);
 
 async function disappearingGifMessageGroup(platform: SupportedPlatformsType, testInfo: TestInfo) {
   const testGroupName = 'Disappear after sent test';
@@ -47,6 +54,7 @@ async function disappearingGifMessageGroup(platform: SupportedPlatformsType, tes
         ...new MediaMessage(device).build(),
         initialMaxWait,
         maxWait,
+        expectedDuration,
         actualStartTime: sentTimestamp,
       })
     )

--- a/run/test/specs/mobile/group_disappearing_messages_image.spec.ts
+++ b/run/test/specs/mobile/group_disappearing_messages_image.spec.ts
@@ -1,11 +1,14 @@
 import type { TestInfo } from '@playwright/test';
 
 import { bothPlatformsIt } from '../../../types/sessionIt';
-import { DISAPPEARING_TIMES } from '../../../types/testing';
 import { MediaMessage, MessageBody } from '../../locators/conversation';
 import { open_Alice1_Bob1_Charlie1_friends_group } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappearing image message to group',
@@ -22,9 +25,9 @@ bothPlatformsIt({
 async function disappearingImageMessageGroup(platform: SupportedPlatformsType, testInfo: TestInfo) {
   const testMessage = 'Testing disappearing messages for images';
   const testGroupName = 'Testing disappearing messages';
-  const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
+  const time = getDisappearingTestTime();
   const timerType = 'Disappear after send option';
-  const maxWait = 35_000; // 30s plus buffer
+  const { expectedDuration, maxWait } = getDisappearingTestTiming();
   const {
     devices: { alice1, bob1, charlie1 },
   } = await open_Alice1_Bob1_Charlie1_friends_group({
@@ -42,6 +45,7 @@ async function disappearingImageMessageGroup(platform: SupportedPlatformsType, t
         device.hasElementDisappeared({
           ...new MessageBody(device, testMessage).build(),
           maxWait,
+          expectedDuration,
           actualStartTime: sentTimestamp,
         })
       )
@@ -56,6 +60,7 @@ async function disappearingImageMessageGroup(platform: SupportedPlatformsType, t
         device.hasElementDisappeared({
           ...new MediaMessage(device).build(),
           maxWait,
+          expectedDuration,
           actualStartTime: sentTimestamp,
         })
       )

--- a/run/test/specs/mobile/group_disappearing_messages_link.spec.ts
+++ b/run/test/specs/mobile/group_disappearing_messages_link.spec.ts
@@ -4,8 +4,7 @@ import { testLink } from '../../../constants';
 import { tStripped } from '../../../localizer/lib';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
-import { DISAPPEARING_TIMES } from '../../../types/testing';
-import { LinkPreviewMessage } from '../../locators';
+import { LinkPreview, LinkPreviewMessage } from '../../locators';
 import {
   MessageBody,
   MessageInput,
@@ -14,9 +13,12 @@ import {
 } from '../../locators/conversation';
 import { EnableLinkPreviewsModalButton } from '../../locators/global';
 import { open_Alice1_Bob1_Charlie1_friends_group } from '../../state_builder';
-import { sleepFor } from '../../utils';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappearing link to group',
@@ -30,8 +32,8 @@ bothPlatformsIt({
   allureDescription: 'Verifies that a link preview disappears as expected in a group conversation',
 });
 const timerType = 'Disappear after send option';
-const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
-const maxWait = 35_000; // 30s plus buffer
+const time = getDisappearingTestTime();
+const { expectedDuration, maxWait } = getDisappearingTestTiming();
 
 async function disappearingLinkMessageGroup(platform: SupportedPlatformsType, testInfo: TestInfo) {
   let sentTimestamp: number;
@@ -63,8 +65,8 @@ async function disappearingLinkMessageGroup(platform: SupportedPlatformsType, te
     // On iOS, Appium types so the link preview modal interrupts typing the link, must be deleted and typed again
     await alice1.onIOS().deleteText(new MessageInput(alice1));
     await alice1.onIOS().inputText(testLink, new MessageInput(alice1));
-    // Let preview load
-    await sleepFor(5000);
+    // Let the preview load (poll rather than a fixed sleep)
+    await alice1.waitForTextElementToBePresent(new LinkPreview(alice1));
     await alice1.clickOnElementAll(new SendButton(alice1));
     await alice1.waitForTextElementToBePresent({
       ...new OutgoingMessageStatusSent(alice1).build(),
@@ -72,7 +74,7 @@ async function disappearingLinkMessageGroup(platform: SupportedPlatformsType, te
     });
     sentTimestamp = Date.now();
   });
-  // Wait for 30 seconds to disappear
+  // Wait out the disappearing timer
   await test.step(TestSteps.VERIFY.MESSAGE_DISAPPEARED, async () => {
     if (platform === 'ios') {
       await Promise.all(
@@ -80,6 +82,7 @@ async function disappearingLinkMessageGroup(platform: SupportedPlatformsType, te
           device.hasElementDisappeared({
             ...new MessageBody(device, testLink).build(),
             maxWait,
+            expectedDuration,
             actualStartTime: sentTimestamp,
           })
         )
@@ -91,6 +94,7 @@ async function disappearingLinkMessageGroup(platform: SupportedPlatformsType, te
           device.hasElementDisappeared({
             ...new LinkPreviewMessage(device).build(),
             maxWait,
+            expectedDuration,
             actualStartTime: sentTimestamp,
           })
         )

--- a/run/test/specs/mobile/group_disappearing_messages_members.spec.ts
+++ b/run/test/specs/mobile/group_disappearing_messages_members.spec.ts
@@ -47,7 +47,7 @@ async function membersCantSetDisappearingMessages(
     .onIOS()
     .clickOnElementAll(new DisappearingMessageRadial(bob1, DISAPPEARING_TIMES.ONE_DAY));
   // Set button should not be visible
-  await bob1.verifyElementNotPresent({
+  await bob1.waitForElementToBeGone({
     ...new SetDisappearMessagesButton(bob1).build(),
     maxWait: 500,
   });

--- a/run/test/specs/mobile/group_disappearing_messages_video.spec.ts
+++ b/run/test/specs/mobile/group_disappearing_messages_video.spec.ts
@@ -5,7 +5,11 @@ import { DISAPPEARING_TIMES } from '../../../types/testing';
 import { MediaMessage, MessageBody } from '../../locators/conversation';
 import { open_Alice1_Bob1_Charlie1_friends_group } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappearing video to group',
@@ -20,10 +24,13 @@ bothPlatformsIt({
 });
 
 // Sending and receiving the video can take a while so this is bumped to 60s
-const time = DISAPPEARING_TIMES.ONE_MINUTE;
+const time = getDisappearingTestTime(DISAPPEARING_TIMES.ONE_MINUTE);
 const timerType = 'Disappear after send option';
 const initialMaxWait = 20_000; // Downloading the attachment can take a while
-const maxWait = 70_000; // 60s plus buffer
+const { expectedDuration, maxWait } = getDisappearingTestTiming(
+  DISAPPEARING_TIMES.ONE_MINUTE,
+  10_000
+);
 
 async function disappearingVideoMessageGroup(platform: SupportedPlatformsType, testInfo: TestInfo) {
   const testMessage = 'Testing disappearing messages for videos';
@@ -52,6 +59,7 @@ async function disappearingVideoMessageGroup(platform: SupportedPlatformsType, t
         device.hasElementDisappeared({
           ...new MessageBody(device, testMessage).build(),
           maxWait,
+          expectedDuration,
           actualStartTime: sentTimestamp,
         })
       )
@@ -63,6 +71,7 @@ async function disappearingVideoMessageGroup(platform: SupportedPlatformsType, t
           ...new MediaMessage(device).build(),
           initialMaxWait,
           maxWait,
+          expectedDuration,
           actualStartTime: sentTimestamp,
         })
       )

--- a/run/test/specs/mobile/group_disappearing_messages_voice.spec.ts
+++ b/run/test/specs/mobile/group_disappearing_messages_voice.spec.ts
@@ -1,10 +1,14 @@
 import type { TestInfo } from '@playwright/test';
 
 import { bothPlatformsIt } from '../../../types/sessionIt';
-import { DISAPPEARING_TIMES, GROUPNAME } from '../../../types/testing';
+import { GROUPNAME } from '../../../types/testing';
 import { open_Alice1_Bob1_Charlie1_friends_group } from '../../state_builder';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
-import { setDisappearingMessage } from '../../utils/set_disappearing_messages';
+import {
+  getDisappearingTestTime,
+  getDisappearingTestTiming,
+  setDisappearingMessage,
+} from '../../utils/set_disappearing_messages';
 
 bothPlatformsIt({
   title: 'Disappearing voice message to group',
@@ -20,9 +24,9 @@ bothPlatformsIt({
 
 async function disappearingVoiceMessageGroup(platform: SupportedPlatformsType, testInfo: TestInfo) {
   const testGroupName: GROUPNAME = 'Testing voice';
-  const time = DISAPPEARING_TIMES.THIRTY_SECONDS;
+  const time = getDisappearingTestTime();
   const timerType = 'Disappear after send option';
-  const maxWait = 35_000; // 30s plus buffer
+  const { expectedDuration, maxWait } = getDisappearingTestTiming();
   const {
     devices: { alice1, bob1, charlie1 },
   } = await open_Alice1_Bob1_Charlie1_friends_group({
@@ -42,6 +46,7 @@ async function disappearingVoiceMessageGroup(platform: SupportedPlatformsType, t
         strategy: 'accessibility id',
         selector: 'Voice message',
         maxWait,
+        expectedDuration,
         actualStartTime: sentTimestamp,
       })
     )

--- a/run/test/specs/mobile/group_message_document.spec.ts
+++ b/run/test/specs/mobile/group_message_document.spec.ts
@@ -79,8 +79,6 @@ async function sendDocumentGroupAndroid(platform: SupportedPlatformsType, testIn
     )
   );
   // Reply to image - user B
-  // Sleep for is waiting for image to load
-  await sleepFor(1000);
   await bob1.longPressMessage(new DocumentMessage(bob1));
   await bob1.clickOnByAccessibilityID('Reply to message');
   await bob1.sendMessage(replyMessage);

--- a/run/test/specs/mobile/group_message_gif.spec.ts
+++ b/run/test/specs/mobile/group_message_gif.spec.ts
@@ -45,8 +45,6 @@ async function sendGifGroupiOS(platform: SupportedPlatformsType, testInfo: TestI
     [bob1, charlie1].map(device => device.waitForTextElementToBePresent(new MediaMessage(device)))
   );
   // Reply to image - user B
-  // Sleep for is waiting for image to load
-  await sleepFor(1000);
   await bob1.longPressMessage(new MediaMessage(bob1));
   // Check reply came through on alice1
   await bob1.clickOnByAccessibilityID('Reply to message');

--- a/run/test/specs/mobile/group_message_image.spec.ts
+++ b/run/test/specs/mobile/group_message_image.spec.ts
@@ -88,8 +88,6 @@ async function sendImageGroupAndroid(platform: SupportedPlatformsType, testInfo:
     [bob1, charlie1].map(device => device.waitForTextElementToBePresent(new MediaMessage(device)))
   );
   // Reply to image - user B
-  // Sleep for is waiting for image to load
-  await sleepFor(1000);
   await bob1.longPressMessage(new MediaMessage(bob1));
   await bob1.clickOnByAccessibilityID('Reply to message');
   await bob1.sendMessage(replyMessage);

--- a/run/test/specs/mobile/group_message_link_preview.spec.ts
+++ b/run/test/specs/mobile/group_message_link_preview.spec.ts
@@ -102,8 +102,8 @@ async function sendLinkGroupAndroid(platform: SupportedPlatformsType, testInfo: 
     tStripped('linkPreviewsFirstDescription')
   );
   await alice1.clickOnElementAll(new EnableLinkPreviewsModalButton(alice1));
-  //wait for preview to generate
-  await sleepFor(5000);
+  // Wait for the link preview to generate (poll rather than a fixed sleep)
+  await alice1.waitForTextElementToBePresent(new LinkPreview(alice1));
   // No preview on first send
   await alice1.clickOnElementAll(new SendButton(alice1));
   await alice1.waitForTextElementToBePresent({

--- a/run/test/specs/mobile/group_reaction.spec.ts
+++ b/run/test/specs/mobile/group_reaction.spec.ts
@@ -47,7 +47,7 @@ async function sendEmojiReactionGroup(platform: SupportedPlatformsType, testInfo
         await device.longPressMessage(new MessageBody(device, message));
         await device.clickOnElementAll(new FirstEmojiReact(device));
         // Verify long press menu disappeared (so next found emoji is in convo and not in react bar)
-        await device.verifyElementNotPresent({
+        await device.waitForElementToBeGone({
           strategy: 'accessibility id',
           selector: 'Reply to message',
         });

--- a/run/test/specs/mobile/group_tests_add_accountid.spec.ts
+++ b/run/test/specs/mobile/group_tests_add_accountid.spec.ts
@@ -18,7 +18,6 @@ import {
 import { MessageRequestItem, MessageRequestsBanner } from '../../locators/home';
 import { EnterAccountID, NextButton } from '../../locators/start_conversation';
 import { open_Alice1_Bob1_Charlie1_Unknown1 } from '../../state_builder';
-import { sleepFor } from '../../utils';
 import { newUser } from '../../utils/create_account';
 import { truncatePubkey } from '../../utils/get_account_id';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
@@ -69,7 +68,6 @@ async function addAccountIDToGroup(platform: SupportedPlatformsType, testInfo: T
     await alice1.clickOnElementAll(new ConversationSettings(alice1));
     // Select edit group
     await alice1.clickOnElementAll(new ManageMembersMenuItem(alice1));
-    await sleepFor(1000);
     // Add contact to group
     await alice1.clickOnElementAll(new InviteAccountIDOrONS(alice1));
     await alice1.inputText(userD.accountID, new EnterAccountID(alice1));

--- a/run/test/specs/mobile/group_tests_add_contact.spec.ts
+++ b/run/test/specs/mobile/group_tests_add_contact.spec.ts
@@ -15,7 +15,6 @@ import {
 } from '../../locators/groups';
 import { ConversationItem } from '../../locators/home';
 import { open_Alice1_Bob1_Charlie1_Unknown1 } from '../../state_builder';
-import { sleepFor } from '../../utils';
 import { newUser } from '../../utils/create_account';
 import { newContact } from '../../utils/create_contact';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
@@ -71,7 +70,6 @@ async function addContactToGroupHistory(platform: SupportedPlatformsType, testIn
     await alice1.clickOnElementAll(new ConversationSettings(alice1));
     // Select edit group
     await alice1.clickOnElementAll(new ManageMembersMenuItem(alice1));
-    await sleepFor(1000);
     // Add contact to group
     await alice1.clickOnElementAll(new InviteContactsMenuItem(alice1));
     // Select new user

--- a/run/test/specs/mobile/group_tests_add_contact_nohistory.spec.ts
+++ b/run/test/specs/mobile/group_tests_add_contact_nohistory.spec.ts
@@ -15,7 +15,6 @@ import {
 } from '../../locators/groups';
 import { ConversationItem } from '../../locators/home';
 import { open_Alice1_Bob1_Charlie1_Unknown1 } from '../../state_builder';
-import { sleepFor } from '../../utils';
 import { newUser } from '../../utils/create_account';
 import { newContact } from '../../utils/create_contact';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
@@ -71,7 +70,6 @@ async function addContactToGroupNoHistory(platform: SupportedPlatformsType, test
     await alice1.clickOnElementAll(new ConversationSettings(alice1));
     // Select edit group
     await alice1.clickOnElementAll(new ManageMembersMenuItem(alice1));
-    await sleepFor(1000);
     // Add contact to group
     await alice1.clickOnElementAll(new InviteContactsMenuItem(alice1));
     // Select new user

--- a/run/test/specs/mobile/group_tests_admin_leave_group.spec.ts
+++ b/run/test/specs/mobile/group_tests_admin_leave_group.spec.ts
@@ -19,7 +19,6 @@ import {
 } from '../../locators/groups';
 import { ConversationItem, PlusButton } from '../../locators/home';
 import { open_Alice1_Bob1_Charlie1_friends_group } from '../../state_builder';
-import { sleepFor } from '../../utils';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
 
 androidIt({
@@ -100,7 +99,7 @@ async function soloAdminLeave(platform: SupportedPlatformsType, testInfo: TestIn
       )
     );
     await alice1.waitForTextElementToBePresent(new PlusButton(alice1)); // Ensure we're on the home screen
-    await alice1.verifyElementNotPresent(new ConversationItem(alice1, testGroupName).build());
+    await alice1.waitForElementToBeGone(new ConversationItem(alice1, testGroupName).build());
   });
 
   await test.step(TestSteps.SETUP.CLOSE_APP, async () => {
@@ -159,10 +158,9 @@ async function multiAdminLeave(platform: SupportedPlatformsType, testInfo: TestI
   await test.step('Verify promotion status is correct', async () => {
     await alice1.clickOnElementAll(new ConversationSettings(alice1));
     await alice1.clickOnElementAll(new ManageAdminsMenuItem(alice1));
-    await alice1.verifyElementNotPresent(
+    await alice1.waitForElementToBeGone(
       new MemberStatus(alice1).build(tStripped('adminPromotionSent'))
     );
-    await sleepFor(1_000);
   });
   await test.step(TestSteps.VERIFY.SPECIFIC_MODAL('Leave Group'), async () => {
     await alice1.navigateBack();
@@ -184,7 +182,7 @@ async function multiAdminLeave(platform: SupportedPlatformsType, testInfo: TestI
       )
     );
     await alice1.waitForTextElementToBePresent(new PlusButton(alice1));
-    await alice1.verifyElementNotPresent(new ConversationItem(alice1, testGroupName).build());
+    await alice1.waitForElementToBeGone(new ConversationItem(alice1, testGroupName).build());
   });
   await test.step(TestSteps.SETUP.CLOSE_APP, async () => {
     await closeApp(alice1, bob1, charlie1);

--- a/run/test/specs/mobile/group_tests_change_group_description.spec.ts
+++ b/run/test/specs/mobile/group_tests_change_group_description.spec.ts
@@ -15,7 +15,6 @@ import {
 } from '../../locators/groups';
 import { ErrorMessage } from '../../locators/onboarding';
 import { open_Alice1_Bob1_Charlie1_friends_group } from '../../state_builder';
-import { sleepFor } from '../../utils';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
 
 bothPlatformsItSeparate({
@@ -67,7 +66,6 @@ async function changeGroupDescriptionIOS(platform: SupportedPlatformsType, testI
 
   await test.step(TestSteps.OPEN.UPDATE_GROUP_INFO, async () => {
     await alice1.clickOnElementAll(new ConversationSettings(alice1));
-    await sleepFor(1000);
     await alice1.clickOnElementAll(new UpdateGroupInformation(alice1, testGroupName));
   });
 
@@ -117,7 +115,6 @@ async function changeGroupDescriptionAndroid(platform: SupportedPlatformsType, t
 
   await test.step(TestSteps.OPEN.UPDATE_GROUP_INFO, async () => {
     await alice1.clickOnElementAll(new ConversationSettings(alice1));
-    await sleepFor(1000);
     await alice1.clickOnElementAll(new UpdateGroupInformation(alice1, testGroupName));
   });
 

--- a/run/test/specs/mobile/group_tests_change_group_name.spec.ts
+++ b/run/test/specs/mobile/group_tests_change_group_name.spec.ts
@@ -9,7 +9,6 @@ import {
   UpdateGroupInformation,
 } from '../../locators/groups';
 import { open_Alice1_Bob1_Charlie1_friends_group } from '../../state_builder';
-import { sleepFor } from '../../utils';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
 
 bothPlatformsItSeparate({
@@ -44,7 +43,6 @@ async function changeGroupNameIos(platform: SupportedPlatformsType, testInfo: Te
   // Click on settings or three dots
   await alice1.clickOnElementAll(new ConversationSettings(alice1));
   // Click on Edit group option
-  await sleepFor(1000);
   // Click on current group name
   await alice1.clickOnElementAll(new UpdateGroupInformation(alice1, testGroupName));
   await alice1.checkModalStrings(
@@ -92,7 +90,6 @@ async function changeGroupNameAndroid(platform: SupportedPlatformsType, testInfo
   // Click on settings or three dots
   await alice1.clickOnElementAll(new ConversationSettings(alice1));
   // Click on Edit group option
-  await sleepFor(1000);
   await alice1.clickOnElementAll(new UpdateGroupInformation(alice1));
   await alice1.clickOnElementAll({ strategy: 'id', selector: 'clear-input-button-name' });
   await alice1.clickOnElementAll(new EditGroupNameInput(alice1));

--- a/run/test/specs/mobile/group_tests_create_group_banner.spec.ts
+++ b/run/test/specs/mobile/group_tests_create_group_banner.spec.ts
@@ -33,6 +33,6 @@ async function createGroupBanner(platform: SupportedPlatformsType, testInfo: Tes
   await alice1.clickOnElementAll(new PlusButton(alice1));
   await alice1.clickOnElementAll(new CreateGroupOption(alice1));
   // Verify the banner is not present
-  await alice1.verifyElementNotPresent(new LatestReleaseBanner(alice1));
+  await alice1.waitForElementToBeGone(new LatestReleaseBanner(alice1));
   await closeApp(alice1, bob1);
 }

--- a/run/test/specs/mobile/group_tests_delete_group.spec.ts
+++ b/run/test/specs/mobile/group_tests_delete_group.spec.ts
@@ -75,7 +75,7 @@ async function deleteGroup(platform: SupportedPlatformsType, testInfo: TestInfo)
     await Promise.all(
       [alice1, alice2].map(async device => {
         await device.waitForTextElementToBePresent(new PlusButton(device)); // Ensure we're on the home screen
-        await device.verifyElementNotPresent(new ConversationItem(device, testGroupName).build());
+        await device.waitForElementToBeGone(new ConversationItem(device, testGroupName).build());
       })
     );
   });

--- a/run/test/specs/mobile/group_tests_edit_group_banner.spec.ts
+++ b/run/test/specs/mobile/group_tests_edit_group_banner.spec.ts
@@ -33,6 +33,6 @@ async function editGroupBanner(platform: SupportedPlatformsType, testInfo: TestI
   // Navigate to Edit Group screen
   await alice1.clickOnElementAll(new ConversationSettings(alice1));
   await alice1.clickOnElementAll(new ManageMembersMenuItem(alice1));
-  await alice1.verifyElementNotPresent(new LatestReleaseBanner(alice1));
+  await alice1.waitForElementToBeGone(new LatestReleaseBanner(alice1));
   await closeApp(alice1, bob1, charlie1);
 }

--- a/run/test/specs/mobile/group_tests_invite_contact_banner.spec.ts
+++ b/run/test/specs/mobile/group_tests_invite_contact_banner.spec.ts
@@ -35,6 +35,6 @@ async function inviteContactGroupBanner(platform: SupportedPlatformsType, testIn
   await alice1.clickOnElementAll(new ConversationSettings(alice1));
   await alice1.clickOnElementAll(new ManageMembersMenuItem(alice1));
   await alice1.clickOnElementAll(new InviteContactsMenuItem(alice1));
-  await alice1.verifyElementNotPresent(new LatestReleaseBanner(alice1));
+  await alice1.waitForElementToBeGone(new LatestReleaseBanner(alice1));
   await closeApp(alice1, bob1, charlie1);
 }

--- a/run/test/specs/mobile/group_tests_kick_member.spec.ts
+++ b/run/test/specs/mobile/group_tests_kick_member.spec.ts
@@ -55,7 +55,7 @@ async function kickMember(platform: SupportedPlatformsType, testInfo: TestInfo) 
     await alice1.clickOnElementAll(new ConfirmRemovalButton(alice1));
     // The Group Member element sometimes disappears slowly, sometimes quickly.
     // hasElementBeenDeleted would be theoretically better but we just check if element is not there anymore
-    await alice1.verifyElementNotPresent({
+    await alice1.waitForElementToBeGone({
       ...new GroupMember(alice1).build(USERNAME.BOB),
       maxWait: 5_000,
     });

--- a/run/test/specs/mobile/group_tests_kick_member_messages.spec.ts
+++ b/run/test/specs/mobile/group_tests_kick_member_messages.spec.ts
@@ -73,9 +73,9 @@ async function kickMemberDeleteMsg(platform: SupportedPlatformsType, testInfo: T
     });
     await alice1.clickOnElementAll(new RemoveMemberMessagesRadial(alice1));
     await alice1.clickOnElementAll(new ConfirmRemovalButton(alice1));
-    // The Group Member element sometimes disappears slowly, sometimes quickly.
-    // hasElementBeenDeleted would be theoretically better but we just check if element is not there anymore
-    await alice1.verifyElementNotPresent({
+    // The Group Member element sometimes disappears slowly, sometimes quickly, so poll for it to be
+    // gone (returns as soon as it's absent) rather than always waiting the full period.
+    await alice1.waitForElementToBeGone({
       ...new GroupMember(alice1).build(USERNAME.BOB),
       maxWait: 5_000,
     });

--- a/run/test/specs/mobile/group_tests_leave_group.spec.ts
+++ b/run/test/specs/mobile/group_tests_leave_group.spec.ts
@@ -6,7 +6,6 @@ import { ConversationSettings } from '../../locators/conversation';
 import { LeaveGroupConfirm, LeaveGroupMenuItem } from '../../locators/groups';
 import { ConversationItem } from '../../locators/home';
 import { open_Alice1_Bob1_Charlie1_friends_group } from '../../state_builder';
-import { sleepFor } from '../../utils/index';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
 
 bothPlatformsIt({
@@ -34,7 +33,6 @@ async function leaveGroup(platform: SupportedPlatformsType, testInfo: TestInfo) 
     testInfo,
   });
   await charlie1.clickOnElementAll(new ConversationSettings(charlie1));
-  await sleepFor(1000);
   await charlie1.clickOnElementAll(new LeaveGroupMenuItem(charlie1));
   // Modal with Leave/Cancel
   await charlie1.checkModalStrings(
@@ -47,7 +45,7 @@ async function leaveGroup(platform: SupportedPlatformsType, testInfo: TestInfo) 
   await alice1.waitForControlMessageToBePresent(groupMemberLeft);
   await bob1.waitForControlMessageToBePresent(groupMemberLeft);
   // Check device 3 that group has disappeared
-  await charlie1.verifyElementNotPresent({
+  await charlie1.waitForElementToBeGone({
     ...new ConversationItem(charlie1, testGroupName).build(),
     maxWait: 5000,
   });

--- a/run/test/specs/mobile/group_tests_promote.spec.ts
+++ b/run/test/specs/mobile/group_tests_promote.spec.ts
@@ -319,7 +319,7 @@ async function promoteMultiToAdmin(platform: SupportedPlatformsType, testInfo: T
   await Promise.all([
     alice1.waitForTextElementToBePresent(new Contact(alice1, bob.userName)),
     alice1.waitForTextElementToBePresent(new Contact(alice1, charlie.userName)),
-    alice1.verifyElementNotPresent({
+    alice1.waitForElementToBeGone({
       ...new MemberStatus(alice1).build(tStripped('adminPromotionSent')),
       maxWait: 10_000,
     }),

--- a/run/test/specs/mobile/linked_device_block_user.spec.ts
+++ b/run/test/specs/mobile/linked_device_block_user.spec.ts
@@ -31,6 +31,10 @@ async function blockUserInConversationOptions(
     devices: { alice1, alice2, bob1 },
     prebuilt: { bob },
   } = await open_Alice2_Bob1_friends({ platform, focusFriendsConvo: true, testInfo });
+  // Establish that the linked device has the conversation *before* blocking, so the check afterwards
+  // only has to watch it go. Doing it the other way round — looking for it once the block is already
+  // in flight — fails whenever the sync gets there first.
+  await alice2.waitForTextElementToBePresent(new ConversationItem(alice2, bob.userName));
   // Block contact
   await alice1.clickOnElementAll(new ConversationSettings(alice1));
   // Select Block option
@@ -43,7 +47,10 @@ async function blockUserInConversationOptions(
   );
   // Confirm block option
   await alice1.clickOnElementAll(new BlockUserConfirmationModal(alice1));
-  await alice2.hasElementBeenDeleted(new ConversationItem(alice2, bob.userName));
+  await alice2.waitForElementToBeGone({
+    ...new ConversationItem(alice2, bob.userName).build(),
+    maxWait: 20_000,
+  });
   await alice1.navigateBack();
   await alice1.waitForTextElementToBePresent(new BlockedBanner(alice1));
   // Check settings for blocked user

--- a/run/test/specs/mobile/linked_device_create_group.spec.ts
+++ b/run/test/specs/mobile/linked_device_create_group.spec.ts
@@ -71,9 +71,8 @@ async function linkedGroupiOS(platform: SupportedPlatformsType, testInfo: TestIn
   const groupNameNew = tStripped('groupNameNew', { group_name: newGroupName });
   // Control message should be "Group name is now {group_name}."
   await device1.waitForControlMessageToBePresent(groupNameNew);
-  // Wait 5 seconds for name to update
-  await sleepFor(5000);
-  // Check linked device for name change (conversation header name)
+  // Check linked device for name change (conversation header name) — this already polls until the
+  // rename syncs, so no fixed sleep is needed.
   await device2.waitForTextElementToBePresent(new ConversationHeaderName(device2, newGroupName));
   await Promise.all([
     device2.waitForControlMessageToBePresent(groupNameNew),
@@ -101,7 +100,6 @@ async function linkedGroupAndroid(platform: SupportedPlatformsType, testInfo: Te
   // Click on settings or three dots
   await device1.clickOnElementAll(new ConversationSettings(device1));
   // Click on Edit group option
-  await sleepFor(1000);
   await device1.clickOnElementAll(new UpdateGroupInformation(device1));
   // Click on current group name
   await device1.clickOnElementAll(new EditGroupNameInput(device1));

--- a/run/test/specs/mobile/linked_device_hide_note_to_self.spec.ts
+++ b/run/test/specs/mobile/linked_device_hide_note_to_self.spec.ts
@@ -52,31 +52,24 @@ async function hideNoteToSelf(platform: SupportedPlatformsType, testInfo: TestIn
     });
     await alice1.clickOnByAccessibilityID('Hide');
   });
+  // Note to Self was shown on alice2 above, before the hide, so both devices only need to be seen to
+  // lose it here. hasElementBeenDeleted would re-check presence first, which races the hide: on
+  // alice2 against the sync, and on alice1 against its own local update.
+  //
+  // The iOS branch this replaces attributed itself to page structure, but both platforms allowed the
+  // same 5s for the element to go — all the extra iOS wait bought was time for it to be *found*
+  // first, which is the phase being dropped. So the windows are unchanged.
   await test.step('Verify Note to Self is hidden on both devices', async () => {
-    if (platform === 'android') {
-      await Promise.all([
-        alice1.waitForElementToBeGone({
-          ...new ConversationItem(alice1, noteToSelf).build(),
-          maxWait: 5_000,
-        }),
-        alice2.hasElementBeenDeleted({
-          ...new ConversationItem(alice2, noteToSelf).build(),
-          maxWait: 20_000,
-        }),
-      ]);
-    } else {
-      // iOS page structure is more flaky and the element can still be present
-      await Promise.all([
-        alice1.hasElementBeenDeleted({
-          ...new ConversationItem(alice1, noteToSelf).build(),
-          maxWait: 5_000,
-        }),
-        alice2.hasElementBeenDeleted({
-          ...new ConversationItem(alice2, noteToSelf).build(),
-          maxWait: 20_000,
-        }),
-      ]);
-    }
+    await Promise.all([
+      alice1.waitForElementToBeGone({
+        ...new ConversationItem(alice1, noteToSelf).build(),
+        maxWait: 5_000,
+      }),
+      alice2.waitForElementToBeGone({
+        ...new ConversationItem(alice2, noteToSelf).build(),
+        maxWait: 20_000,
+      }),
+    ]);
   });
   await test.step(TestSteps.SETUP.CLOSE_APP, async () => {
     await closeApp(alice1, alice2);

--- a/run/test/specs/mobile/linked_device_hide_note_to_self.spec.ts
+++ b/run/test/specs/mobile/linked_device_hide_note_to_self.spec.ts
@@ -55,7 +55,7 @@ async function hideNoteToSelf(platform: SupportedPlatformsType, testInfo: TestIn
   await test.step('Verify Note to Self is hidden on both devices', async () => {
     if (platform === 'android') {
       await Promise.all([
-        alice1.verifyElementNotPresent({
+        alice1.waitForElementToBeGone({
           ...new ConversationItem(alice1, noteToSelf).build(),
           maxWait: 5_000,
         }),

--- a/run/test/specs/mobile/linked_group_leave.spec.ts
+++ b/run/test/specs/mobile/linked_group_leave.spec.ts
@@ -46,7 +46,7 @@ async function leaveGroupLinkedDevice(platform: SupportedPlatformsType, testInfo
   // Check for group not being visible anymore
   await Promise.all(
     [device3, device4].map(device =>
-      device.verifyElementNotPresent({
+      device.waitForElementToBeGone({
         ...new ConversationItem(device, testGroupName).build(),
         maxWait: 10_000,
       })

--- a/run/test/specs/mobile/message_length.spec.ts
+++ b/run/test/specs/mobile/message_length.spec.ts
@@ -131,7 +131,10 @@ for (const testCase of messageLengthTestCases) {
             new MessageLengthCountdown(device, expectedCount)
           );
         } else {
-          await device.verifyElementNotPresent(new MessageLengthCountdown(device));
+          await device.verifyElementNotPresent({
+            ...new MessageLengthCountdown(device).build(),
+            maxWait: 1000,
+          });
         }
 
         await device.clickOnElementAll(new SendButton(device));
@@ -143,7 +146,10 @@ for (const testCase of messageLengthTestCases) {
           // For Non Pro, a CTA appears
           await device.checkCTA('longerMessages');
           await device.clickOnElementAll(new CTAButtonNegative(device));
-          await device.verifyElementNotPresent(new MessageBody(device, message));
+          await device.verifyElementNotPresent({
+            ...new MessageBody(device, message).build(),
+            maxWait: 1000,
+          });
         } else if (testCase.pro) {
           // For Pro, a normal message length dialog appears
           await device.checkModalStrings(
@@ -151,7 +157,10 @@ for (const testCase of messageLengthTestCases) {
             tStripped('modalMessageTooLongDescription', { limit: expectedMax.toString() })
           );
           await device.clickOnElementAll(new MessageLengthOkayButton(device));
-          await device.verifyElementNotPresent(new MessageBody(device, message));
+          await device.verifyElementNotPresent({
+            ...new MessageBody(device, message).build(),
+            maxWait: 1000,
+          });
         }
       });
 

--- a/run/test/specs/mobile/message_reaction.spec.ts
+++ b/run/test/specs/mobile/message_reaction.spec.ts
@@ -38,7 +38,7 @@ async function sendEmojiReaction(platform: SupportedPlatformsType, testInfo: Tes
     await bob1.longPressMessage(new MessageBody(bob1, message));
     await bob1.clickOnElementAll(new FirstEmojiReact(bob1));
     // Verify long press menu disappeared (so next found emoji is in convo and not in react bar)
-    await bob1.verifyElementNotPresent({
+    await bob1.waitForElementToBeGone({
       strategy: 'accessibility id',
       selector: 'Reply to message',
     });

--- a/run/test/specs/mobile/message_requests_block.spec.ts
+++ b/run/test/specs/mobile/message_requests_block.spec.ts
@@ -39,7 +39,6 @@ async function blockedRequest(platform: SupportedPlatformsType, testInfo: TestIn
   // Bob clicks on block option
   await device2.clickOnByAccessibilityID('Block message request');
   // Confirm block on android
-  await sleepFor(1000);
   await device2.checkModalStrings(
     tStripped('block'),
     tStripped('blockDescription', { name: alice.userName })
@@ -52,7 +51,7 @@ async function blockedRequest(platform: SupportedPlatformsType, testInfo: TestIn
       strategy: 'accessibility id',
       selector: messageRequestsNonePending as AccessibilityId,
     }),
-    device3.verifyElementNotPresent({
+    device3.waitForElementToBeGone({
       ...new MessageRequestsBanner(device3).build(),
       maxWait: 10_000,
     }),

--- a/run/test/specs/mobile/message_video.spec.ts
+++ b/run/test/specs/mobile/message_video.spec.ts
@@ -3,7 +3,6 @@ import type { TestInfo } from '@playwright/test';
 import { bothPlatformsItSeparate } from '../../../types/sessionIt';
 import { MediaMessage, MessageBody } from '../../locators/conversation';
 import { open_Alice1_Bob1_friends } from '../../state_builder';
-import { sleepFor } from '../../utils';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
 
 bothPlatformsItSeparate({
@@ -68,7 +67,6 @@ async function sendVideoAndroid(platform: SupportedPlatformsType, testInfo: Test
   await bob1.longPressMessage(new MediaMessage(bob1));
   await bob1.clickOnByAccessibilityID('Reply to message');
   await bob1.sendMessage(replyMessage);
-  await sleepFor(2000);
   await alice1.waitForTextElementToBePresent(new MessageBody(alice1, replyMessage));
   // Close app and server
   await closeApp(alice1, bob1);

--- a/run/test/specs/mobile/recovery_banner.spec.ts
+++ b/run/test/specs/mobile/recovery_banner.spec.ts
@@ -55,7 +55,7 @@ androidIt({
 
 async function bannerShouldNotShow(device: DeviceWrapper) {
   await device.waitForTextElementToBePresent(new PlusButton(device));
-  await device.verifyElementNotPresent(new RevealRecoveryPhraseButton(device));
+  await device.waitForElementToBeGone(new RevealRecoveryPhraseButton(device));
   device.log('On home screen, banner did not appear');
 }
 
@@ -115,7 +115,7 @@ async function bannerPersists(platform: SupportedPlatformsType, testInfo: TestIn
     await device.longPressConversation(communities.testCommunity.name);
     await device.clickOnElementAll({ strategy: 'accessibility id', selector: 'Leave' }); // Long press options
     await device.clickOnElementAll({ strategy: 'accessibility id', selector: 'Leave' }); // Modal confirm
-    await device.verifyElementNotPresent(
+    await device.waitForElementToBeGone(
       new ConversationItem(device, communities.testCommunity.name)
     );
     await bannerShouldShow(device);

--- a/run/test/specs/mobile/review_once.spec.ts
+++ b/run/test/specs/mobile/review_once.spec.ts
@@ -54,7 +54,7 @@ async function reviewPromptOnce(platform: SupportedPlatformsType, testInfo: Test
   });
   await test.step('Verify review prompt is not shown again', async () => {
     await device.waitForTextElementToBePresent(new PlusButton(device)); // Making sure we're on the home screen
-    await device.verifyElementNotPresent(new ModalHeading(device));
+    await device.waitForElementToBeGone(new ModalHeading(device));
   });
   await test.step(TestSteps.SETUP.CLOSE_APP, async () => {
     await closeApp(device);

--- a/run/test/specs/mobile/review_positive.spec.ts
+++ b/run/test/specs/mobile/review_positive.spec.ts
@@ -56,7 +56,7 @@ async function reviewPromptPositive(platform: SupportedPlatformsType, testInfo: 
       tStripped('rateSessionModalDescriptionUpdated', { storevariant })
     );
     await device.waitForTextElementToBePresent(new ReviewPromptRateAppButton(device));
-    await device.verifyElementNotPresent(new ReviewPromptNotNowButton(device)); // This modal now only has the Rate button
+    await device.waitForElementToBeGone(new ReviewPromptNotNowButton(device)); // This modal now only has the Rate button
   });
   await test.step(TestSteps.SETUP.CLOSE_APP, async () => {
     await closeApp(device);

--- a/run/test/specs/mobile/user_actions_block_conversation_list.spec.ts
+++ b/run/test/specs/mobile/user_actions_block_conversation_list.spec.ts
@@ -42,7 +42,7 @@ async function blockUserInConversationList(platform: SupportedPlatformsType, tes
   );
   await alice1.clickOnByAccessibilityID('Block');
   // Once you block the conversation disappears from the home screen
-  await alice1.verifyElementNotPresent({
+  await alice1.waitForElementToBeGone({
     ...new ConversationItem(alice1, bob.userName).build(),
     maxWait: 5_000,
   });

--- a/run/test/specs/mobile/user_actions_block_conversation_options.spec.ts
+++ b/run/test/specs/mobile/user_actions_block_conversation_options.spec.ts
@@ -53,7 +53,6 @@ async function blockUserInConversationSettings(
   );
   // Confirm block option
   await alice1.clickOnElementAll(new BlockUserConfirmationModal(alice1));
-  await sleepFor(1000);
   // Navigate back to conversation screen to confirm block
   await alice1.navigateBack();
   // Look for alert at top of screen (Bob is blocked. Unblock them?)

--- a/run/test/specs/mobile/user_actions_delete_contact_ucs.spec.ts
+++ b/run/test/specs/mobile/user_actions_delete_contact_ucs.spec.ts
@@ -56,13 +56,16 @@ async function deleteContactCS(platform: SupportedPlatformsType, testInfo: TestI
     await alice1.clickOnElementAll(new DeleteContactConfirmButton(alice1));
   });
 
+  // Both devices were shown to have the conversation above, before the delete, so we only need to
+  // see it go here. hasElementBeenDeleted would re-check presence first, which on alice2 races the
+  // delete syncing across — if the sync lands before that check, the test fails for being fast.
   await test.step('Verify contact deleted on both alice devices', async () => {
     await Promise.all([
       alice1.waitForElementToBeGone({
         ...new ConversationItem(alice1, bob.userName).build(),
         maxWait: 5_000,
       }),
-      alice2.hasElementBeenDeleted({
+      alice2.waitForElementToBeGone({
         ...new ConversationItem(alice2, bob.userName).build(),
         maxWait: 20_000,
       }),

--- a/run/test/specs/mobile/user_actions_delete_contact_ucs.spec.ts
+++ b/run/test/specs/mobile/user_actions_delete_contact_ucs.spec.ts
@@ -58,7 +58,7 @@ async function deleteContactCS(platform: SupportedPlatformsType, testInfo: TestI
 
   await test.step('Verify contact deleted on both alice devices', async () => {
     await Promise.all([
-      alice1.verifyElementNotPresent({
+      alice1.waitForElementToBeGone({
         ...new ConversationItem(alice1, bob.userName).build(),
         maxWait: 5_000,
       }),

--- a/run/test/specs/mobile/user_actions_delete_conversation.spec.ts
+++ b/run/test/specs/mobile/user_actions_delete_conversation.spec.ts
@@ -53,7 +53,7 @@ async function deleteConversation(platform: SupportedPlatformsType, testInfo: Te
 
   await test.step('Verify conversation deleted on both alice devices', async () => {
     await Promise.all([
-      alice1.verifyElementNotPresent({
+      alice1.waitForElementToBeGone({
         ...new ConversationItem(alice1, bob.userName).build(),
         maxWait: 5_000,
       }),

--- a/run/test/specs/mobile/user_actions_delete_conversation.spec.ts
+++ b/run/test/specs/mobile/user_actions_delete_conversation.spec.ts
@@ -51,13 +51,16 @@ async function deleteConversation(platform: SupportedPlatformsType, testInfo: Te
     await alice1.clickOnByAccessibilityID('Delete');
   });
 
+  // Both devices were shown to have the conversation above, before the delete, so we only need to
+  // see it go here. hasElementBeenDeleted would re-check presence first, which on alice2 races the
+  // delete syncing across — if the sync lands before that check, the test fails for being fast.
   await test.step('Verify conversation deleted on both alice devices', async () => {
     await Promise.all([
       alice1.waitForElementToBeGone({
         ...new ConversationItem(alice1, bob.userName).build(),
         maxWait: 5_000,
       }),
-      alice2.hasElementBeenDeleted({
+      alice2.waitForElementToBeGone({
         ...new ConversationItem(alice2, bob.userName).build(),
         maxWait: 20_000,
       }),

--- a/run/test/specs/mobile/user_actions_delete_conversation_ucs.spec.ts
+++ b/run/test/specs/mobile/user_actions_delete_conversation_ucs.spec.ts
@@ -55,7 +55,7 @@ async function deleteConversationCS(platform: SupportedPlatformsType, testInfo: 
 
   await test.step('Verify conversation deleted on both alice devices', async () => {
     await Promise.all([
-      alice1.verifyElementNotPresent({
+      alice1.waitForElementToBeGone({
         ...new ConversationItem(alice1, bob.userName).build(),
         maxWait: 5_000,
       }),

--- a/run/test/specs/mobile/user_actions_delete_conversation_ucs.spec.ts
+++ b/run/test/specs/mobile/user_actions_delete_conversation_ucs.spec.ts
@@ -53,13 +53,16 @@ async function deleteConversationCS(platform: SupportedPlatformsType, testInfo: 
     await alice1.clickOnElementAll(new DeleteConversationModalConfirm(alice1));
   });
 
+  // Both devices were shown to have the conversation above, before the delete, so we only need to
+  // see it go here. hasElementBeenDeleted would re-check presence first, which on alice2 races the
+  // delete syncing across — if the sync lands before that check, the test fails for being fast.
   await test.step('Verify conversation deleted on both alice devices', async () => {
     await Promise.all([
       alice1.waitForElementToBeGone({
         ...new ConversationItem(alice1, bob.userName).build(),
         maxWait: 5_000,
       }),
-      alice2.hasElementBeenDeleted({
+      alice2.waitForElementToBeGone({
         ...new ConversationItem(alice2, bob.userName).build(),
         maxWait: 20_000,
       }),

--- a/run/test/specs/mobile/user_actions_hide_note_to_self.spec.ts
+++ b/run/test/specs/mobile/user_actions_hide_note_to_self.spec.ts
@@ -69,7 +69,7 @@ async function hideNoteToSelf(platform: SupportedPlatformsType, testInfo: TestIn
   await device.clickOnElementAll(new CancelSearchButton(device));
 
   await test.step('Verify Note to Self is hidden', async () => {
-    await device.verifyElementNotPresent({
+    await device.waitForElementToBeGone({
       ...new ConversationItem(device, noteToSelf).build(),
       maxWait: 2000,
     });

--- a/run/test/specs/mobile/user_actions_hide_recovery_password.spec.ts
+++ b/run/test/specs/mobile/user_actions_hide_recovery_password.spec.ts
@@ -43,7 +43,7 @@ async function hideRecoveryPassword(platform: SupportedPlatformsType, testInfo: 
   // Click on Yes
   await device1.clickOnElementAll(new YesButton(device1));
   // Has recovery password menu item disappeared?
-  await device1.verifyElementNotPresent({
+  await device1.waitForElementToBeGone({
     ...new RecoveryPasswordMenuItem(device1).build(),
     maxWait: 1000,
   });

--- a/run/test/specs/mobile/user_actions_lock_app.spec.ts
+++ b/run/test/specs/mobile/user_actions_lock_app.spec.ts
@@ -54,7 +54,7 @@ async function lockApp(platform: SupportedPlatformsType, testInfo: TestInfo) {
       // The unlock screen is not visible to appium so there's no real way to tell it appeared
       // Other than waiting a long time to make sure the home screen (plus button) never appeared
       // This prevents the false positive where we send key events to nowhere and the lock screen never appeared anyway
-      await device.verifyElementNotPresent({ ...new PlusButton(device).build(), maxWait: 10_000 });
+      await device.waitForElementToBeGone({ ...new PlusButton(device).build(), maxWait: 10_000 });
     });
     await test.step('Enter PIN to unlock app', async () => {
       await runScriptAndLog(`adb -s ${device.udid} shell input text ${pin}`, true);

--- a/run/test/specs/mobile/user_actions_pin_unpin.spec.ts
+++ b/run/test/specs/mobile/user_actions_pin_unpin.spec.ts
@@ -92,7 +92,7 @@ async function pinConversation(platform: SupportedPlatformsType, testInfo: TestI
   });
   if (platform === 'android') {
     await test.step('Assert pin icon is gone after unpinning', async () => {
-      await device.verifyElementNotPresent(new ConversationPinnedIcon(device, toPin));
+      await device.waitForElementToBeGone(new ConversationPinnedIcon(device, toPin));
     });
   }
   await test.step(TestSteps.SETUP.CLOSE_APP, async () => {

--- a/run/test/specs/mobile/user_actions_unblock_user.spec.ts
+++ b/run/test/specs/mobile/user_actions_unblock_user.spec.ts
@@ -60,5 +60,5 @@ async function unblockUser(platform: SupportedPlatformsType, testInfo: TestInfo)
     tStripped('blockUnblockName', { name: bob.userName })
   );
   await alice1.clickOnElementAll({ strategy: 'accessibility id', selector: 'Unblock' });
-  await alice1.verifyElementNotPresent({ ...new BlockedBanner(alice1).build(), maxWait: 2000 });
+  await alice1.waitForElementToBeGone({ ...new BlockedBanner(alice1).build(), maxWait: 2000 });
 }

--- a/run/test/specs/mobile/voice_calls.spec.ts
+++ b/run/test/specs/mobile/voice_calls.spec.ts
@@ -7,7 +7,6 @@ import { CloseSettings } from '../../locators';
 import { CallButton, NotificationSwitch } from '../../locators/conversation';
 import { SettingsModalsEnableButton } from '../../locators/settings';
 import { open_Alice1_Bob1_friends } from '../../state_builder';
-import { sleepFor } from '../../utils/index';
 import { closeApp, SupportedPlatformsType } from '../../utils/open_app';
 
 bothPlatformsItSeparate({
@@ -62,16 +61,16 @@ async function voiceCallIos(platform: SupportedPlatformsType, testInfo: TestInfo
     await alice1.clickOnElementAll(new SettingsModalsEnableButton(alice1));
     // Need to allow microphone access
     await alice1.modalPopup({ strategy: 'accessibility id', selector: 'Allow' });
-    await sleepFor(1_000);
     // Need to allow camera access
     await alice1.modalPopup({ strategy: 'accessibility id', selector: 'Allow' });
-    await sleepFor(10_000); // Wait a bit for the toggles to turn to TRUE
-    const aliceLocalNetworkSwitch = await alice1.waitForTextElementToBePresent({
-      strategy: 'accessibility id',
-      selector: 'Local Network Permission - Switch',
-    });
-    const aliceAttr = await alice1.getAttribute('value', aliceLocalNetworkSwitch.ELEMENT);
-    if (aliceAttr !== '1') {
+    // Poll the toggle until it flips to enabled rather than a fixed 10s wait — returns as soon as
+    // it's on (this auto-grant is a known-flaky Simulator behaviour).
+    const aliceLocalNetworkEnabled = await alice1.waitForElementValue(
+      { strategy: 'accessibility id', selector: 'Local Network Permission - Switch' },
+      '1',
+      10_000
+    );
+    if (!aliceLocalNetworkEnabled) {
       throw new Error(
         `Local Network Permission was not enabled automatically.
       This is a known Simulator bug that fails randomly with no pattern or fix.
@@ -107,16 +106,16 @@ async function voiceCallIos(platform: SupportedPlatformsType, testInfo: TestInfo
   await bob1.clickOnElementAll(new SettingsModalsEnableButton(bob1));
   // Need to allow microphone access
   await bob1.modalPopup({ strategy: 'accessibility id', selector: 'Allow' });
-  await sleepFor(1_000);
   // Need to allow camera access
   await bob1.modalPopup({ strategy: 'accessibility id', selector: 'Allow' });
-  await sleepFor(10_000); // Wait a bit for the toggles to turn to TRUE
-  const bobLocalNetworkSwitch = await bob1.waitForTextElementToBePresent({
-    strategy: 'accessibility id',
-    selector: 'Local Network Permission - Switch',
-  });
-  const bobAttr = await bob1.getAttribute('value', bobLocalNetworkSwitch.ELEMENT);
-  if (bobAttr !== '1') {
+  // Poll the toggle until it flips to enabled rather than a fixed 10s wait — returns as soon as
+  // it's on (this auto-grant is a known-flaky Simulator behaviour).
+  const bobLocalNetworkEnabled = await bob1.waitForElementValue(
+    { strategy: 'accessibility id', selector: 'Local Network Permission - Switch' },
+    '1',
+    10_000
+  );
+  if (!bobLocalNetworkEnabled) {
     throw new Error(
       `Local Network Permission was not enabled automatically.
       This is a known Simulator bug that fails randomly with no pattern or fix.

--- a/run/test/utils/capabilities_ios.ts
+++ b/run/test/utils/capabilities_ios.ts
@@ -218,6 +218,11 @@ const sharediOSCapabilities: AppiumXCUITestCapabilities = {
   'appium:showXcodeLog': false,
   'appium:autoDismissAlerts': false,
   'appium:reduceMotion': true,
+  // WDA waits for the app to be idle before each command. A disappearing-message countdown repaints
+  // every second, so the app never becomes idle and the wait runs to WDA's own limit — single
+  // findElements calls have been measured at 21s and 60s. This bounds that wait rather than removing
+  // it: ordinary screens still get synchronised, a ticking one costs a second.
+  'appium:waitForIdleTimeout': 1,
   'appium:processArguments': {
     env: {
       debugDisappearingMessageDurations: 'true',

--- a/run/test/utils/capabilities_ios.ts
+++ b/run/test/utils/capabilities_ios.ts
@@ -2,8 +2,10 @@ import type { Capabilities } from '@wdio/types';
 
 import { W3CXCUITestDriverCaps } from 'appium-xcuitest-driver/build/lib/driver';
 import dotenv from 'dotenv';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync } from 'fs';
 
+import { WDA_DERIVED_DATA_PATH, WDA_PREBUILT_APP_PATH } from '../../../scripts/build_wda';
+import { resolveRunSimulators, type Simulator } from '../../../scripts/ios_shared';
 import { IntRange } from '../../types/RangeType';
 
 dotenv.config({ quiet: true });
@@ -177,7 +179,34 @@ if (!iosPathPrefix) {
 const iosAppFullPath = `${iosPathPrefix}`;
 console.log(`iOS app full path: ${iosAppFullPath}`);
 
+// Reuse a prebuilt WebDriverAgent runner instead of building/launching WDA via `xcodebuild` on
+// every session. Freshly-created simulators have no WDA installed, so without this the driver
+// rebuilds+launches WDA per session — the slowest, flakiest part of startup on a cold clone (it
+// intermittently dies before binding wdaLocalPort → `ECONNREFUSED 127.0.0.1:<port>`) and forces a
+// redundant reinstall of the app-under-test around the test runner. With a prebuilt runner the
+// driver installs it with `simctl` and launches it directly — no per-session xcodebuild.
+//
+// Build it once with `pnpm build-wda` (run_ios_parallel does this automatically). These caps only
+// activate when the prebuilt runner actually exists, so plain `pnpm test-ios` / CI runs that
+// haven't built it fall back to the driver's default build-per-session behaviour.
+// Typed loosely because the @wdio caps type doesn't declare the prebuilt-WDA keys; the shared
+// template below is `as`-cast to AppiumXCUITestCapabilities, which is where they get applied.
+const wdaCapabilities: Record<string, boolean | number | string> = existsSync(WDA_PREBUILT_APP_PATH)
+  ? {
+      'appium:usePreinstalledWDA': true,
+      'appium:prebuiltWDAPath': WDA_PREBUILT_APP_PATH,
+      'appium:derivedDataPath': WDA_DERIVED_DATA_PATH,
+      'appium:wdaLaunchTimeout': 120000,
+      'appium:wdaConnectionTimeout': 120000,
+    }
+  : {};
+
+if (Object.keys(wdaCapabilities).length === 0) {
+  console.log('No prebuilt WDA found — WDA will build per session. Run `pnpm build-wda` to reuse.');
+}
+
 const sharediOSCapabilities: AppiumXCUITestCapabilities = {
+  ...wdaCapabilities,
   'appium:app': iosAppFullPath,
   'appium:platformName': 'iOS',
   'appium:platformVersion': '26.2',
@@ -198,70 +227,41 @@ const sharediOSCapabilities: AppiumXCUITestCapabilities = {
   },
 } as AppiumXCUITestCapabilities;
 
-export type Simulator = {
-  name: string;
-  udid: string;
-  wdaPort: number;
-};
+// Re-exported for the scripts that build/clean simulators; the resolution itself lives in
+// scripts/ios_shared so global-setup can use it without importing this iOS-only module.
+export type { Simulator };
 
-function loadSimulators(): Simulator[] {
-  const jsonPath = 'ci-simulators.json';
+const simulators = resolveRunSimulators();
 
-  // Load from .env variables
-  const envVars = [
-    'IOS_1_SIMULATOR',
-    'IOS_2_SIMULATOR',
-    'IOS_3_SIMULATOR',
-    'IOS_4_SIMULATOR',
-    'IOS_5_SIMULATOR',
-    'IOS_6_SIMULATOR',
-    'IOS_7_SIMULATOR',
-    'IOS_8_SIMULATOR',
-    'IOS_9_SIMULATOR',
-    'IOS_10_SIMULATOR',
-    'IOS_11_SIMULATOR',
-    'IOS_12_SIMULATOR',
-  ];
+// Ports where global-setup started a long-lived WebDriverAgent (local runs only). Devices covered
+// here attach to that WDA via `webDriverAgentUrl`, which reduces the driver's WDA launch to a single
+// `/status` call — it skips both the per-session install AND the cross-device lock that otherwise
+// serialises session startup (~8s saved on a 3-device test). Anything not listed keeps the
+// prebuilt-WDA path below, so a WDA that failed to start just costs speed, not correctness.
+const wdaReusePorts = new Set(
+  (process.env.WDA_REUSE_PORTS ?? '')
+    .split(',')
+    .map(port => parseInt(port.trim()))
+    .filter(port => Number.isFinite(port))
+);
 
-  const simulators = envVars
-    .map((envVar, index) => {
-      const udid = process.env[envVar];
-      if (!udid) return null; // No need for all 12 sim variables to be set
-      return { name: `Sim-${index + 1}`, udid, wdaPort: 1253 + index };
-    })
-    .filter((sim): sim is Simulator => sim !== null);
+const capabilities = simulators.map(sim => {
+  const base = {
+    ...sharediOSCapabilities,
+    'appium:udid': sim.udid,
+    'appium:wdaLocalPort': sim.wdaPort,
+  } as Record<string, unknown>;
 
-  // If we have simulators from env, use them (local dev)
-  if (simulators.length > 0) {
-    console.log(`Using ${simulators.length} simulators from .env file`);
-    return simulators;
+  if (wdaReusePorts.has(sim.wdaPort)) {
+    // `usePreinstalledWDA` must go: the driver still runs its install step when that cap is set,
+    // even though `webDriverAgentUrl` takes precedence for the launch itself.
+    delete base['appium:usePreinstalledWDA'];
+    delete base['appium:prebuiltWDAPath'];
+    base['appium:webDriverAgentUrl'] = `http://127.0.0.1:${sim.wdaPort}`;
   }
 
-  // No env simulators - check if we're on CI
-  if (process.env.CI === '1') {
-    // CI should use JSON
-    if (existsSync(jsonPath)) {
-      console.log('Using simulators from ios-simulators.json (CI)');
-      const sims: Simulator[] = JSON.parse(readFileSync(jsonPath, 'utf-8'));
-      return sims;
-    }
-    throw new Error('CI mode: ios-simulators.json not found');
-  }
-
-  // Local dev with no .env entries
-  throw new Error(
-    'No iOS simulators found in .env\n' +
-      'Run: pnpm create-simulators <number>\n' +
-      'Example: pnpm create-simulators 4'
-  );
-}
-const simulators = loadSimulators();
-
-const capabilities = simulators.map(sim => ({
-  ...sharediOSCapabilities,
-  'appium:udid': sim.udid,
-  'appium:wdaLocalPort': sim.wdaPort,
-}));
+  return base as AppiumXCUITestCapabilities;
+});
 
 // Use a constant max that matches the envVars array length for type safety
 const _MAX_CAPABILITIES_INDEX = 12 as const;

--- a/run/test/utils/create_contact.ts
+++ b/run/test/utils/create_contact.ts
@@ -52,7 +52,8 @@ export const retryMsgSentForBanner = async (
     if (!messageRequest) {
       device1.log(`Retrying message request`);
       await device1.sendMessage('Retry');
-      await sleepFor(5000);
+      // No fixed sleep: the next loop iteration's doesElementExist(maxWait: 5000) already polls for
+      // the banner, giving the retried request time to arrive.
     } else {
       device2.log('Found message request: No need for retry');
     }

--- a/run/test/utils/handle_first_open.ts
+++ b/run/test/utils/handle_first_open.ts
@@ -7,10 +7,10 @@ import { iOSPhotosContinuebutton } from '../locators/external';
 // If someone already pressed the "Use without an account" button, only the notifications prompt may appear.
 export async function handleChromeFirstTimeOpen(device: DeviceWrapper) {
   const [useWithoutAccount, notifications] = await Promise.all([
-    device.doesElementExist({ ...new ChromeUseWithoutAnAccount(device).build(), maxWait: 5_000 }),
+    device.doesElementExist({ ...new ChromeUseWithoutAnAccount(device).build(), maxWait: 2_500 }),
     device.doesElementExist({
       ...new ChromeNotificationsNegativeButton(device).build(),
-      maxWait: 5_000,
+      maxWait: 2_500,
     }),
   ]);
 

--- a/run/test/utils/open_app.ts
+++ b/run/test/utils/open_app.ts
@@ -358,7 +358,7 @@ const openiOSApp = async (
     throw new Error(
       `This test needs at least ${capabilitiesIndex + 1} devices, but each worker is allocated ` +
         `only ${devicesPerWorker} simulator(s) (DEVICES_PER_TEST_COUNT=${devicesPerWorker}). ` +
-        `Re-run with a larger pool, e.g. \`pnpm test-ios-parallel --devices ${capabilitiesIndex + 1}\`, ` +
+        `Re-run with a larger pool, e.g. \`pnpm test-ios-parallel --devices-per-worker ${capabilitiesIndex + 1}\`, ` +
         `or filter to tests that fit, e.g. \`--grep '@ios @${devicesPerWorker}-devices'\`.`
     );
   }

--- a/run/test/utils/open_conversation.ts
+++ b/run/test/utils/open_conversation.ts
@@ -1,0 +1,20 @@
+import { DeviceWrapper } from '../../types/DeviceWrapper';
+import { ConversationHeaderName } from '../locators/conversation';
+import { ConversationItem } from '../locators/home';
+
+/**
+ * Opens a conversation from the home screen and confirms we landed in it.
+ *
+ * Tapping a row is not as safe as it looks. The tap goes via an element handle, but an XCUITest
+ * handle is a path into the hierarchy, so when the list re-orders between resolving the row and
+ * clicking it, the handle can resolve onto a different row — silently, without a stale-element
+ * error. Nothing downstream notices: the test carries on against the wrong conversation and fails
+ * later, wherever the first missing element happens to be, with an error that says nothing about
+ * how it got there.
+ *
+ * Checking the header makes that fail immediately, at the point it happened, saying what happened.
+ */
+export async function openConversation(device: DeviceWrapper, conversationName: string) {
+  await device.clickOnElementAll(new ConversationItem(device, conversationName));
+  await device.waitForTextElementToBePresent(new ConversationHeaderName(device, conversationName));
+}

--- a/run/test/utils/restore_account.ts
+++ b/run/test/utils/restore_account.ts
@@ -73,9 +73,12 @@ export const restoreAccountNoFallback = async (
   await device.clickOnElementAll(new ContinueButton(device));
   // Wait for loading animation to look for display name
   await device.waitForLoadingOnboarding();
+  // Here the display name input showing up means the account WASN'T found, so the happy path always
+  // pays this wait in full — keep it short. `waitForLoadingOnboarding` above has already polled the
+  // loading animation away, so the screen has settled and the input would be rendered by now.
   const displayName = await device.doesElementExist({
     ...new DisplayNameInput(device).build(),
-    maxWait: 2000,
+    maxWait: 600,
   });
   if (displayName) {
     const network = process.env.DETECTED_NETWORK_TARGET ?? 'unknown';
@@ -83,8 +86,7 @@ export const restoreAccountNoFallback = async (
   }
   device.info('Display name found: Loading account');
 
-  // Wait for permissions modal to pop up
-  await sleepFor(500);
+  // No settle needed before this — processPermissions polls for the modal itself.
   await handleNotificationPermissions(device, allowNotificationPermissions);
   // A startup CTA (e.g. the "New Hope for Session" donation appeal) can cover the home
   // screen after restore; dismiss it via its close button so the home screen is reachable.

--- a/run/test/utils/restore_account.ts
+++ b/run/test/utils/restore_account.ts
@@ -12,6 +12,36 @@ import {
 import { BaseSetupOptions } from './create_account';
 import { handleNotificationPermissions } from './permissions';
 
+/**
+ * Wait for the home screen, recovering if the notification prompt turned up too late to be caught.
+ *
+ * `processPermissions` polls for the prompt over a fixed window. A prompt that arrives after that
+ * window closes is never dismissed, and it then sits over the home screen — so the next step fails
+ * looking for something it can't reach, with an error that never mentions permissions. Widening the
+ * window only makes that rarer: a 5s probe has been seen missing it.
+ *
+ * So rather than waiting longer, check whether we actually got where we expected and deal with the
+ * prompt if we didn't. The probe costs nothing when the home screen is up, which is the usual case.
+ */
+const waitForHomeScreenAfterOnboarding = async (
+  device: DeviceWrapper,
+  allowNotificationPermissions: boolean
+) => {
+  const onHomeScreen = await device.doesElementExist({
+    ...new PlusButton(device).build(),
+    maxWait: 5_000,
+  });
+  if (onHomeScreen) {
+    return;
+  }
+  device.info(
+    'Home screen not reached after onboarding — checking for a late permission prompt/CTA'
+  );
+  await handleNotificationPermissions(device, allowNotificationPermissions);
+  await device.dismissCTA(true);
+  await device.waitForTextElementToBePresent(new PlusButton(device));
+};
+
 export const restoreAccount = async (
   device: DeviceWrapper,
   user: User,
@@ -48,7 +78,7 @@ export const restoreAccount = async (
   // screen after restore; dismiss it via its close button so the home screen is reachable.
   await device.dismissCTA(true);
   // Check that we're on the home screen
-  await device.waitForTextElementToBePresent(new PlusButton(device));
+  await waitForHomeScreenAfterOnboarding(device, allowNotificationPermissions);
 };
 
 /**
@@ -92,5 +122,5 @@ export const restoreAccountNoFallback = async (
   // screen after restore; dismiss it via its close button so the home screen is reachable.
   await device.dismissCTA(true);
   // Check that we're on the home screen
-  await device.waitForTextElementToBePresent(new PlusButton(device));
+  await waitForHomeScreenAfterOnboarding(device, allowNotificationPermissions);
 };

--- a/run/test/utils/set_disappearing_messages.ts
+++ b/run/test/utils/set_disappearing_messages.ts
@@ -9,9 +9,73 @@ import {
   SetDisappearMessagesButton,
 } from '../locators/disappearing_messages';
 
+/**
+ * The disappearing-message duration the tests should use.
+ *
+ * These specs have to wait out the timer for real, so the duration is a floor on their runtime —
+ * they're the slowest group in the suite. 30 seconds exists because 10 was too tight against
+ * mainnet's onion-routing latency; on a local devnet propagation is near-instant, so 10 is enough
+ * and saves ~20s per spec.
+ *
+ * Devnet is detected two ways because neither alone is sufficient: `DETECTED_NETWORK_TARGET` is the
+ * resolved value (a seed URL when on devnet, on both platforms) but is only set once
+ * `getNetworkTarget` has run, which is after module load — and some specs pick their duration at
+ * module level. `NETWORK_TARGET` is the user-supplied setting, available immediately. Anything we
+ * can't positively identify as devnet keeps its off-devnet duration.
+ *
+ * `offDevnet` is what to use when we're not on a devnet. It defaults to 30 seconds, but specs that
+ * deliberately chose something longer for reliability (community interactions, large attachments)
+ * must pass their own value so this can't silently shorten them on mainnet.
+ */
+export function getDisappearingTestTime(
+  offDevnet: DISAPPEARING_TIMES = DISAPPEARING_TIMES.THIRTY_SECONDS
+): DISAPPEARING_TIMES {
+  const detected = process.env.DETECTED_NETWORK_TARGET ?? '';
+  const requested = (process.env.NETWORK_TARGET ?? '').trim().toLowerCase();
+  const onDevnet = detected.startsWith('http') || requested === 'devnet';
+  return onDevnet ? DISAPPEARING_TIMES.TEN_SECONDS : offDevnet;
+}
+
+/**
+ * Timings for waiting out the disappearing timer, both derived from the duration the test set.
+ *
+ * - `expectedDuration` is the timer itself, and is what the "disappeared suspiciously early" check
+ *   measures against (see hasElementDisappeared).
+ * - `maxWait` is the timeout, and is the timer plus a *fixed* allowance for send, propagation and
+ *   the poll's own debounce. Fixed rather than proportional because that overhead doesn't shrink
+ *   with the timer: at 10 seconds it was observed to add up to ~3.3s, which a proportional buffer
+ *   would not have covered.
+ *
+ * `bufferMs` is that allowance. It defaults to the 5s the text specs used; the attachment specs
+ * pass 10s, matching the extra headroom they already gave themselves for media download. Together
+ * with `offDevnet` this reproduces each spec's previous off-devnet value exactly (35_000, 65_000,
+ * 70_000), so nothing changes away from a devnet.
+ */
+export function getDisappearingTestTiming(
+  offDevnet?: DISAPPEARING_TIMES,
+  bufferMs: number = 5_000
+): {
+  expectedDuration: number;
+  maxWait: number;
+} {
+  const time = getDisappearingTestTime(offDevnet);
+  // Values look like "10 seconds" / "1 minute", so the unit matters — parsing the number alone
+  // would read "1 minute" as 1ms*1000.
+  const [amount, unit] = time.split(' ');
+  const count = Number.parseInt(amount, 10);
+  const unitMs = unit?.startsWith('second') ? 1_000 : unit?.startsWith('minute') ? 60_000 : 0;
+  if (!Number.isFinite(count) || unitMs === 0) {
+    throw new Error(
+      `Cannot derive timings from disappearing time "${time}" — expected seconds or minutes`
+    );
+  }
+  const expectedDuration = count * unitMs;
+  return { expectedDuration, maxWait: expectedDuration + bufferMs };
+}
+
 export const setDisappearingMessage = async (
   device: DeviceWrapper,
-  [conversationType, timerType, timerDuration = DISAPPEARING_TIMES.THIRTY_SECONDS]: MergedOptions
+  [conversationType, timerType, timerDuration = getDisappearingTestTime()]: MergedOptions
 ) => {
   const enforcedType: ConversationType = conversationType;
   await device.clickAndWaitFor(

--- a/run/test/utils/utilities.ts
+++ b/run/test/utils/utilities.ts
@@ -140,13 +140,13 @@ export async function forceStopAndRestart(
       `adb -s ${device.udid} shell am start -n ${androidAppPackage}/${androidAppActivity}`,
       true
     );
-    await sleepFor(1_000);
   } else if (device.isIOS()) {
     await runScriptAndLog(`xcrun simctl terminate ${device.udid} ${iOSBundleId}`, true);
     await sleepFor(1_000);
     await runScriptAndLog(`xcrun simctl launch ${device.udid} ${iOSBundleId}`, true);
-    await sleepFor(1_000);
   }
+  // The post-launch settle is covered by the PlusButton wait below (when waitForRestart is set),
+  // which polls — no fixed sleep needed.
   // Ensure we're on the home screen again if desired
   if (waitForRestart) {
     await device.waitForTextElementToBePresent(new PlusButton(device));

--- a/run/types/DeviceWrapper.ts
+++ b/run/types/DeviceWrapper.ts
@@ -2600,10 +2600,16 @@ export class DeviceWrapper implements IMobileWrapper {
       });
 
       try {
-        // Execute the action in the home screen context
+        // Execute the action in the home screen context.
+        //
+        // Matches the Android branch above. The dialog is normally already up by the time we look
+        // (found on the first poll), so this ceiling costs nothing in the usual case — it's only
+        // paid when no dialog ever arrives. Missing a slow one is expensive though: it goes on to
+        // cover the home screen, and every subsequent step fails against a screen it can't reach,
+        // far from any mention of permissions.
         const iosPermissions = await this.doesElementExist({
           ...locatorConfig,
-          maxWait: 2_000,
+          maxWait: 5_000,
         });
 
         if (iosPermissions) {

--- a/run/types/DeviceWrapper.ts
+++ b/run/types/DeviceWrapper.ts
@@ -1434,6 +1434,7 @@ export class DeviceWrapper implements IMobileWrapper {
       text?: string;
       initialMaxWait?: number;
       maxWait?: number;
+      expectedDuration?: number;
     } & (LocatorsInterface | StrategyExtractionObj)
   ): Promise<void> {
     const { locator, description } = this.resolveLocator(args);
@@ -1453,8 +1454,18 @@ export class DeviceWrapper implements IMobileWrapper {
     // Elements should not disappear too early (could be a DM bug)
     const totalTime = (Date.now() - args.actualStartTime) / 1000;
     const deletionPhaseTime = (Date.now() - foundTime) / 1000;
-    const expectedTotalTime = maxWait / 1000;
-    const minAcceptableTotalTimeFactor = 0.65; // Catches egregiously early deletions but still enough leeway for sending/trusting/receiving
+    // Prefer an explicit `expectedDuration` (the disappearing timer itself) over inferring it from
+    // `maxWait`, which is the timer PLUS an allowance for send/propagation/poll debounce. Inferring
+    // works at 30s, where the allowance is small relative to the timer, but not at 10s: there the
+    // allowance is a third of the total, so a floor derived from the padded timeout lands above the
+    // real deletion time and rejects a perfectly good run.
+    //
+    // The two factors differ because they measure different things. Against the real timer we can
+    // be strict (0.8); against a padded timeout we have to stay loose (0.65) or we'd reject callers
+    // that are behaving correctly. Callers still on the inferred path keep exactly their previous
+    // behaviour.
+    const expectedTotalTime = (args.expectedDuration ?? maxWait) / 1000;
+    const minAcceptableTotalTimeFactor = args.expectedDuration ? 0.8 : 0.65;
     const minAcceptableTotalTime = expectedTotalTime * minAcceptableTotalTimeFactor;
 
     if (totalTime < minAcceptableTotalTime) {
@@ -1959,6 +1970,35 @@ export class DeviceWrapper implements IMobileWrapper {
 
   public async getAttribute(attribute: string, elementId: string) {
     return this.toShared().getAttribute(attribute, elementId);
+  }
+
+  /**
+   * Poll an element's `value` attribute until it equals `expectedValue`, returning true as soon as
+   * it matches (or false on timeout). The element is re-found each iteration because its ref can go
+   * stale while the control updates. Use this instead of a fixed "sleep then read once" wait for an
+   * async control (e.g. the Local Network permission switch flipping to '1' after mic/camera access
+   * is granted) — it returns the moment the value flips rather than always paying the full wait.
+   */
+  public async waitForElementValue(
+    locator: StrategyExtractionObj,
+    expectedValue: string,
+    maxWait: number = 10_000
+  ): Promise<boolean> {
+    const start = Date.now();
+    do {
+      const el = await this.doesElementExist({ ...locator, maxWait: 1_000 });
+      if (el) {
+        try {
+          if ((await this.getAttribute('value', el.ELEMENT)) === expectedValue) {
+            return true;
+          }
+        } catch {
+          // Element went stale as the control updated — re-find on the next iteration.
+        }
+      }
+      await sleepFor(300);
+    } while (Date.now() - start < maxWait);
+    return false;
   }
 
   public async assertAttribute(

--- a/run/types/DeviceWrapper.ts
+++ b/run/types/DeviceWrapper.ts
@@ -902,12 +902,13 @@ export class DeviceWrapper implements IMobileWrapper {
         }
 
         await this.longClick(el, 3000);
-        await sleepFor(1000);
+        // No fixed settle — findWithFallback polls for the menu and returns as soon as it appears
+        // (widened to 2000 to preserve the previous total budget while catching it sooner).
         // Either Pin or Unpin will be present depending on whether the conversation is already pinned
         const longPressSuccess = await this.findWithFallback(
           new PinConversationOption(this),
           new UnpinConversationOption(this),
-          1000
+          2000
         );
 
         if (longPressSuccess) {
@@ -1454,6 +1455,7 @@ export class DeviceWrapper implements IMobileWrapper {
     // Elements should not disappear too early (could be a DM bug)
     const totalTime = (Date.now() - args.actualStartTime) / 1000;
     const deletionPhaseTime = (Date.now() - foundTime) / 1000;
+
     // Prefer an explicit `expectedDuration` (the disappearing timer itself) over inferring it from
     // `maxWait`, which is the timer PLUS an allowance for send/propagation/poll debounce. Inferring
     // works at 30s, where the allowance is small relative to the timer, but not at 10s: there the
@@ -2166,7 +2168,7 @@ export class DeviceWrapper implements IMobileWrapper {
       strategy: 'id',
       selector: 'com.android.permissioncontroller:id/permission_allow_all_button',
     });
-    await sleepFor(2000);
+    // No fixed settle needed — the doesElementExist below already polls up to maxWait for the video.
     let videoElement = await this.doesElementExist({
       strategy: 'id',
       selector: 'android:id/title',
@@ -2250,7 +2252,7 @@ export class DeviceWrapper implements IMobileWrapper {
         strategy: 'id',
         selector: 'com.android.permissioncontroller:id/permission_allow_all_button',
       });
-      await sleepFor(1000);
+      // No fixed settle needed — the doesElementExist below already polls up to maxWait for the file.
       let documentElement = await this.doesElementExist({
         strategy: 'id',
         selector: 'android:id/title',
@@ -2364,7 +2366,7 @@ export class DeviceWrapper implements IMobileWrapper {
       // Push file first
       await this.pushMediaToDevice(uploadPicture);
       await this.clickOnElementAll(new ImagePermissionsModalAllow(this));
-      await sleepFor(1000);
+      // clickOnElementAll below already waits for the 'Image button' — no fixed settle needed.
       await this.clickOnElementAll({
         strategy: 'id',
         selector: 'Image button',
@@ -2428,7 +2430,7 @@ export class DeviceWrapper implements IMobileWrapper {
     // I kept getting stale element references on iOS in this method
     // This is an attempt to let the UI settle before we look for the untrusted attachment
     if (this.isIOS()) {
-      await sleepFor(2000);
+      await sleepFor(1000);
     }
 
     await this.clickOnElementAll({
@@ -2509,8 +2511,13 @@ export class DeviceWrapper implements IMobileWrapper {
   }
 
   public async scrollToBottom() {
+    // The scroll-to-bottom button only exists when the conversation isn't already at the bottom.
+    // Callers reach here with the message view already rendered (e.g. after awaiting a message), so
+    // if the button applies it's already in the tree — a short probe is enough. `maxWait` only
+    // bounds the ABSENT case (a present button returns as soon as it's found), so keeping this low
+    // avoids burning the full wait every time the view opens already at the bottom.
     if (
-      await this.doesElementExist({ ...new ScrollToBottomButton(this).build(), maxWait: 3_000 })
+      await this.doesElementExist({ ...new ScrollToBottomButton(this).build(), maxWait: 1_000 })
     ) {
       await this.clickOnElementAll(new ScrollToBottomButton(this));
     } else {
@@ -2635,9 +2642,12 @@ export class DeviceWrapper implements IMobileWrapper {
 
     try {
       // Execute the action in the home screen context
+      // Honor the caller's maxWait (e.g. cleanPermissions passes a short 500ms probe for a
+      // leftover modal that's normally absent). Only fall back to 3s for callers that expect a
+      // permission dialog to actually appear (present-case → returns as soon as it's found).
       const iosPermissions = await this.doesElementExist({
         ...args,
-        maxWait: 3_000,
+        maxWait: args.maxWait ?? 3_000,
       });
       if (iosPermissions) {
         await this.clickOnElementAll({ ...args, maxWait });
@@ -2765,11 +2775,13 @@ export class DeviceWrapper implements IMobileWrapper {
   }
 
   public async verifyNoCTAShows(): Promise<void> {
+    // A CTA appears synchronously with the action that triggers it, so a short absence window is
+    // enough — no need for verifyElementNotPresent's default 2s per check.
     await Promise.all([
-      this.verifyElementNotPresent(new CTAHeading(this)),
-      this.verifyElementNotPresent(new CTABody(this)),
-      this.verifyElementNotPresent(new CTAButtonNegative(this)),
-      this.verifyElementNotPresent(new CTAButtonPositive(this)),
+      this.verifyElementNotPresent({ ...new CTAHeading(this).build(), maxWait: 1_000 }),
+      this.verifyElementNotPresent({ ...new CTABody(this).build(), maxWait: 1_000 }),
+      this.verifyElementNotPresent({ ...new CTAButtonNegative(this).build(), maxWait: 1_000 }),
+      this.verifyElementNotPresent({ ...new CTAButtonPositive(this).build(), maxWait: 1_000 }),
     ]);
   }
 
@@ -2786,7 +2798,7 @@ export class DeviceWrapper implements IMobileWrapper {
   public async dismissCTA(useCloseButton: boolean = false): Promise<void> {
     const hasCTAAppeared = await this.doesElementExist({
       ...new CTAHeading(this).build(),
-      maxWait: 8_000,
+      maxWait: 3_000,
     });
     this.log(`hasCTAAppeared: ${hasCTAAppeared ? 'true' : 'false'}`);
     if (!hasCTAAppeared) {

--- a/run/types/DeviceWrapper.ts
+++ b/run/types/DeviceWrapper.ts
@@ -1380,6 +1380,12 @@ export class DeviceWrapper implements IMobileWrapper {
    * @throws Error if:
    * - The element is never found within initialMaxWait
    * - The element still exists after maxWait
+   *
+   * Only use this when the element is guaranteed to still be there when phase 1 looks. If whatever
+   * removes it is already under way — a linked device applying a synced delete, say — phase 1 is a
+   * race, and losing it fails the test *because the app was fast*. When presence has already been
+   * asserted before the removal was triggered, use waitForElementToBeGone: the appears-then-
+   * disappears assertion still holds, with the "appears" half anchored where it can't race.
    */
   public async hasElementBeenDeleted(
     args: {

--- a/scripts/build_wda.ts
+++ b/scripts/build_wda.ts
@@ -1,0 +1,112 @@
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import * as path from 'path';
+
+/**
+ * Build the WebDriverAgent (WDA) runner ONCE, up front, so the XCUITest driver can reuse it
+ * across every simulator instead of building/launching it via `xcodebuild` on each session.
+ *
+ * Why this exists: freshly-created simulators (see run_ios_parallel.ts / create_ios_simulators.ts)
+ * have no WDA installed, so without a prebuilt runner the driver rebuilds+launches WDA per session
+ * via `xcodebuild test`. On a cold, just-booted clone that step is both the slowest part of session
+ * startup AND the flakiest — it intermittently dies before binding `wdaLocalPort`, surfacing as
+ * `Unable to start WebDriverAgent session ... ECONNREFUSED 127.0.0.1:<port>`. It also causes the
+ * app-under-test to be installed, WDA brought up, then the app reinstalled around the test runner.
+ *
+ * Building once here + pointing the caps at it (appium:prebuiltWDAPath / usePreinstalledWDA /
+ * derivedDataPath in capabilities_ios.ts) removes `xcodebuild` from the per-session loop entirely:
+ * the driver installs the prebuilt runner with `simctl` and launches it directly.
+ *
+ * Output lives under the gitignored `build/` folder so it never touches the shared Xcode
+ * DerivedData directory (which is unlikely to be cleaned up and would silently eat disk).
+ *
+ * Usage:
+ *   pnpm build-wda            # build if missing (no-op when already built)
+ *   pnpm build-wda --force    # rebuild even if a prebuilt runner already exists
+ *
+ * Overrides:
+ *   WDA_DERIVED_DATA_PATH   absolute derived-data dir (default: <repo>/build/wda/derived)
+ *   WDA_PREBUILT_WDA_PATH   absolute path to the prebuilt *-Runner.app (default: derived from above)
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+/** Derived-data directory WDA is built into (env-overridable). */
+export const WDA_DERIVED_DATA_PATH =
+  process.env.WDA_DERIVED_DATA_PATH ?? path.join(REPO_ROOT, 'build', 'wda', 'derived');
+
+/** The prebuilt WDA runner `.app` the driver installs+launches (env-overridable). */
+export const WDA_PREBUILT_APP_PATH =
+  process.env.WDA_PREBUILT_WDA_PATH ??
+  path.join(
+    WDA_DERIVED_DATA_PATH,
+    'Build',
+    'Products',
+    'Debug-iphonesimulator',
+    'WebDriverAgentRunner-Runner.app'
+  );
+
+/**
+ * Locate the `appium-webdriveragent` package the XCUITest driver actually loads, so the WDA we
+ * build matches the one the driver expects at runtime (pnpm may keep several versions on disk).
+ */
+function resolveWdaProject(): string {
+  const driverPkg = require.resolve('appium-xcuitest-driver/package.json', {
+    paths: [REPO_ROOT],
+  });
+  const wdaPkg = require.resolve('appium-webdriveragent/package.json', {
+    paths: [path.dirname(driverPkg)],
+  });
+  const project = path.join(path.dirname(wdaPkg), 'WebDriverAgent.xcodeproj');
+  if (!existsSync(project)) {
+    throw new Error(`Could not find WebDriverAgent.xcodeproj at ${project}`);
+  }
+  return project;
+}
+
+/** Build the WDA runner into WDA_DERIVED_DATA_PATH. */
+export function buildWda(options?: { force?: boolean }): string {
+  if (!options?.force && existsSync(WDA_PREBUILT_APP_PATH)) {
+    console.log(`WDA runner already built: ${WDA_PREBUILT_APP_PATH}`);
+    return WDA_PREBUILT_APP_PATH;
+  }
+
+  const project = resolveWdaProject();
+  console.log(`Building WebDriverAgent (one-off) -> ${WDA_DERIVED_DATA_PATH}`);
+  // build-for-testing produces the *-Runner.app without needing code signing on the simulator SDK.
+  execSync(
+    [
+      'xcodebuild build-for-testing',
+      `-project "${project}"`,
+      '-scheme WebDriverAgentRunner',
+      `-destination 'generic/platform=iOS Simulator'`,
+      `-derivedDataPath "${WDA_DERIVED_DATA_PATH}"`,
+      'CODE_SIGNING_ALLOWED=NO',
+    ].join(' '),
+    { stdio: 'inherit' }
+  );
+
+  if (!existsSync(WDA_PREBUILT_APP_PATH)) {
+    throw new Error(
+      `WDA build reported success but the runner app is missing at ${WDA_PREBUILT_APP_PATH}`
+    );
+  }
+  console.log(`✓ WDA runner ready: ${WDA_PREBUILT_APP_PATH}`);
+  return WDA_PREBUILT_APP_PATH;
+}
+
+/** Build WDA only if it isn't already present. Returns the prebuilt runner path. */
+export function ensureWdaBuilt(): string {
+  return buildWda({ force: false });
+}
+
+// CLI entry (only when invoked directly, e.g. `pnpm build-wda`).
+if (require.main === module) {
+  try {
+    buildWda({ force: process.argv.includes('--force') });
+  } catch (error) {
+    console.error('\n✗ Failed to build WebDriverAgent');
+    console.error(error);
+    process.exit(1);
+  }
+}

--- a/scripts/ios_shared.ts
+++ b/scripts/ios_shared.ts
@@ -1,5 +1,9 @@
-import { execSync } from 'child_process';
+import { exec, execSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
 import { chunk } from 'lodash';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
 
 export type IosRuntime = { identifier: string; version: string };
 
@@ -107,6 +111,216 @@ export function bootSimulator(udid: string, label?: number | string): boolean {
     console.error(error.stderr?.toString() || error.message);
     return false;
   }
+}
+
+/**
+ * Boot every simulator in `udids` concurrently, returning once they have all finished booting.
+ *
+ * Simulators are created shut down, so without this the first test to touch a given device pays
+ * the cold-boot cost inline — and it lands on the critical path at the very start of a run, when
+ * every Playwright worker is booting its own pool simultaneously. Booting up front gets it out of
+ * the way (and makes the cost visible as its own step rather than hiding inside the first test).
+ *
+ * Never throws: a simulator that fails to pre-boot is logged and left for Appium to boot on demand,
+ * exactly as before. A best-effort optimisation should not be able to abort a run.
+ */
+export async function bootSimulatorPool(udids: string[]): Promise<void> {
+  if (udids.length === 0) {
+    return;
+  }
+
+  const start = Date.now();
+  console.log(`Pre-booting ${udids.length} simulator(s)...`);
+
+  await Promise.all(
+    udids.map(async udid => {
+      try {
+        // `bootstatus -b` boots the device if it isn't already booted and only returns once the
+        // boot has actually completed (unlike `simctl boot`, which returns immediately).
+        await execAsync(`xcrun simctl bootstatus ${udid} -b`);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`  Failed to pre-boot ${udid} (Appium will boot it on demand): ${message}`);
+      }
+    })
+  );
+
+  console.log(`✓ Simulators ready in ${((Date.now() - start) / 1000).toFixed(1)}s`);
+}
+
+/**
+ * Install `appPath` on every booted simulator in `udids`, concurrently.
+ *
+ * Appium installs the app as part of creating a session, but on a simulator that doesn't have it
+ * yet that install lands inline in the first test to touch the device — measured at ~150s for three
+ * devices, versus ~17s once they're warm. Doing it up front moves that off the critical path.
+ *
+ * `simctl install` is an upsert, so this is cheap (and effectively a no-op) when the app is already
+ * present and unchanged. Best-effort: failures are logged and left for Appium to handle, since the
+ * session-creation path installs the app anyway.
+ */
+export async function installAppOnSimulators(udids: string[], appPath: string): Promise<void> {
+  if (udids.length === 0 || !appPath) {
+    return;
+  }
+
+  const start = Date.now();
+  console.log(`Pre-installing the app on ${udids.length} simulator(s)...`);
+
+  await Promise.all(
+    udids.map(async udid => {
+      try {
+        await execAsync(`xcrun simctl install ${udid} "${appPath}"`);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`  Failed to pre-install on ${udid} (Appium will install it): ${message}`);
+      }
+    })
+  );
+
+  console.log(`✓ App pre-installed in ${((Date.now() - start) / 1000).toFixed(1)}s`);
+}
+
+/** First `wdaLocalPort`; simulator N (0-based) uses WDA_BASE_PORT + N. */
+export const WDA_BASE_PORT = 1253;
+
+export type Simulator = {
+  name: string;
+  udid: string;
+  wdaPort: number;
+};
+
+/**
+ * The simulators this run will use, from `.env` locally or `ci-simulators.json` on CI, each with
+ * the `wdaLocalPort` it is addressed on.
+ *
+ * Lives here rather than in capabilities_ios so that global-setup can prepare these devices without
+ * importing that module (which validates iOS-only env vars at load time and would therefore break
+ * Android runs).
+ */
+export function resolveRunSimulators(): Simulator[] {
+  const fromEnv: Simulator[] = [];
+  for (let index = 0; index < MAX_SIMULATORS; index++) {
+    const udid = getSimulatorUDID(index + 1);
+    if (!udid) {
+      break; // Not all 12 need to be set; stop at the first gap.
+    }
+    fromEnv.push({ name: `Sim-${index + 1}`, udid, wdaPort: WDA_BASE_PORT + index });
+  }
+
+  if (fromEnv.length > 0) {
+    console.log(`Using ${fromEnv.length} simulators from .env file`);
+    return fromEnv;
+  }
+
+  const jsonPath = 'ci-simulators.json';
+  if (process.env.CI === '1') {
+    if (existsSync(jsonPath)) {
+      console.log('Using simulators from ci-simulators.json (CI)');
+      return JSON.parse(readFileSync(jsonPath, 'utf-8')) as Simulator[];
+    }
+    throw new Error(`CI mode: ${jsonPath} not found`);
+  }
+
+  throw new Error(
+    'No iOS simulators found in .env\n' +
+      'Run: pnpm create-simulators <number>\n' +
+      'Example: pnpm create-simulators 4'
+  );
+}
+
+const WDA_RUNNER_BUNDLE_ID = 'com.facebook.WebDriverAgentRunner.xctrunner';
+
+/** Is a WebDriverAgent answering on this port? */
+async function isWdaResponding(port: number): Promise<boolean> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/status`, {
+      signal: AbortSignal.timeout(2_000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Start a long-lived WebDriverAgent on each simulator and return the ports that came up.
+ *
+ * By default the XCUITest driver installs and launches WDA inside *every* session, and it does so
+ * behind a process-wide lock (`SHARED_RESOURCES_GUARD`, keyed on the literal `'XCUITestDriver'`
+ * whenever `usePreinstalledWDA` is set — see `retrieveDerivedDataPath`, which returns undefined on
+ * that path, so a per-device `derivedDataPath` cannot unlock it). That serialises session startup
+ * across devices at roughly 4.3s each.
+ *
+ * Pointing the driver at an already-running WDA via `webDriverAgentUrl` collapses its launch to a
+ * single `/status` call (see `WebDriverAgent#launch`), which removes both the per-session install
+ * and the serialisation. Measured at ~8s saved on a 3-device test.
+ *
+ * Best-effort: only ports confirmed responding are returned, and callers fall back to the driver's
+ * own WDA handling for anything missing.
+ */
+export async function launchWdaOnSimulators(
+  entries: Array<{ udid: string; port: number }>,
+  wdaAppPath: string
+): Promise<number[]> {
+  if (entries.length === 0 || !wdaAppPath) {
+    return [];
+  }
+
+  const start = Date.now();
+  console.log(`Starting WebDriverAgent on ${entries.length} simulator(s)...`);
+
+  const launched = await Promise.all(
+    entries.map(async ({ udid, port }) => {
+      try {
+        if (await isWdaResponding(port)) {
+          return port; // Left running by an earlier run — reuse it as-is.
+        }
+        await execAsync(`xcrun simctl install ${udid} "${wdaAppPath}"`);
+        // Mirrors what the driver itself does (WebDriverAgent#launchWithPreinstalledWDA): simctl
+        // passes SIMCTL_CHILD_-prefixed vars through to the launched process.
+        await execAsync(
+          `SIMCTL_CHILD_USE_PORT=${port} ` +
+            `SIMCTL_CHILD_WDA_PRODUCT_BUNDLE_IDENTIFIER=${WDA_RUNNER_BUNDLE_ID} ` +
+            `xcrun simctl launch --terminate-running-process ${udid} ${WDA_RUNNER_BUNDLE_ID}`
+        );
+
+        // WDA binds its port a moment after the process starts, so poll rather than assume.
+        for (let attempt = 0; attempt < 30; attempt++) {
+          if (await isWdaResponding(port)) {
+            return port;
+          }
+          await new Promise(resolve => setTimeout(resolve, 500));
+        }
+        console.warn(`  WDA on ${udid} (port ${port}) did not come up; falling back for it`);
+        return null;
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`  Failed to start WDA on ${udid}: ${message}`);
+        return null;
+      }
+    })
+  );
+
+  const ports = launched.filter((port): port is number => port !== null);
+  console.log(
+    `✓ WebDriverAgent ready on ${ports.length}/${entries.length} simulator(s) in ` +
+      `${((Date.now() - start) / 1000).toFixed(1)}s`
+  );
+  return ports;
+}
+
+/** UDIDs of the configured IOS_N_SIMULATOR entries, in order, stopping at the first unset one. */
+export function getConfiguredSimulatorUDIDs(max: number = MAX_SIMULATORS): string[] {
+  const udids: string[] = [];
+  for (let index = 1; index <= max; index++) {
+    const udid = getSimulatorUDID(index);
+    if (!udid) {
+      break;
+    }
+    udids.push(udid);
+  }
+  return udids;
 }
 
 export function isSimulatorBooted(udid: string) {

--- a/scripts/ios_shared.ts
+++ b/scripts/ios_shared.ts
@@ -199,6 +199,16 @@ export type Simulator = {
  * Android runs).
  */
 export function resolveRunSimulators(): Simulator[] {
+  if (process.env.CI === '1') {
+    const jsonPath = 'ci-simulators.json';
+
+    if (existsSync(jsonPath)) {
+      console.log('Using simulators from ci-simulators.json (CI)');
+      return JSON.parse(readFileSync(jsonPath, 'utf-8')) as Simulator[];
+    }
+    throw new Error(`CI mode: ${jsonPath} not found`);
+  }
+
   const fromEnv: Simulator[] = [];
   for (let index = 0; index < MAX_SIMULATORS; index++) {
     const udid = getSimulatorUDID(index + 1);
@@ -211,15 +221,6 @@ export function resolveRunSimulators(): Simulator[] {
   if (fromEnv.length > 0) {
     console.log(`Using ${fromEnv.length} simulators from .env file`);
     return fromEnv;
-  }
-
-  const jsonPath = 'ci-simulators.json';
-  if (process.env.CI === '1') {
-    if (existsSync(jsonPath)) {
-      console.log('Using simulators from ci-simulators.json (CI)');
-      return JSON.parse(readFileSync(jsonPath, 'utf-8')) as Simulator[];
-    }
-    throw new Error(`CI mode: ${jsonPath} not found`);
   }
 
   throw new Error(

--- a/scripts/run_ios_parallel.ts
+++ b/scripts/run_ios_parallel.ts
@@ -6,6 +6,8 @@ import {
   type IosServiceNetwork,
   type Simulator,
 } from '../run/test/utils/capabilities_ios';
+
+import { ensureWdaBuilt } from './build_wda';
 import { createIOSSimulators, resolveDeviceConfig } from './create_ios_simulators';
 import { deleteSimulators } from './ios_shared';
 
@@ -18,16 +20,16 @@ import { deleteSimulators } from './ios_shared';
  * inspection or for reuse with `pnpm test-ios`.
  *
  * Why this exists: locally the suite runs single-worker, so ~250 iOS tests execute one at a
- * time. Each Playwright worker owns a fixed pool of `--devices` simulators (offset by its
+ * time. Each Playwright worker owns a fixed pool of `--devices-per-worker` simulators (offset by its
  * worker index — see openiOSApp in open_app.ts), so N workers need N * devices simulators.
  * This script provisions exactly that many, wires their UDIDs into the child process's
  * environment (without touching your .env), and cleans up after itself.
  *
  * Usage:
- *   pnpm test-ios-parallel                          # 2 workers x 2 devices (4 sims), grep @ios
- *   pnpm test-ios-parallel --devices 4              # 2 workers x 4 devices (8 sims)
- *   pnpm test-ios-parallel --workers 3 --devices 4  # 3 workers x 4 devices (12 sims)
- *   pnpm test-ios-parallel --grep '@ios @high-risk' # subset
+ *   pnpm test-ios-parallel                                      # 2 workers x 2 devices (4 sims), grep @ios
+ *   pnpm test-ios-parallel --devices-per-worker 4               # 2 workers x 4 devices (8 sims)
+ *   pnpm test-ios-parallel --workers 3 --devices-per-worker 4   # 3 workers x 4 devices (12 sims)
+ *   pnpm test-ios-parallel --grep '@ios @high-risk'             # subset
  *   pnpm test-ios-parallel --keep                   # don't delete simulators afterwards
  *   pnpm test-ios-parallel --runtime 26.1           # pin the iOS runtime (default: newest)
  *   pnpm test-ios-parallel --network devnet         # run against devnet (needs DEVNET_* in .env)
@@ -41,11 +43,15 @@ import { deleteSimulators } from './ios_shared';
  *   - `--runtime` picks the iOS simulator runtime (a version like "26.1" or a full identifier).
  *     If omitted, the preferred runtime is used when installed, otherwise the newest installed
  *     iOS runtime. Device type is overridable via the IOS_SIM_DEVICE_TYPE env var.
- *   - `--devices` is the per-worker simulator pool. It must be >= the largest test's device
- *     count in your grep, otherwise those tests fail fast with a clear error (see openiOSApp).
- *     The default of 2 covers @1-devices / @2-devices tests; use `--devices 4` to include the
- *     @3-devices / @4-devices tests (i.e. the full suite).
- *   - Simulators are created shut down; Appium boots each on demand at session start (as on CI).
+ *   - `--devices-per-worker` is the per-worker simulator pool. It must be >=
+ *     the largest test's device count in your grep, otherwise those tests fail fast with a clear
+ *     error (see openiOSApp). The default of 2 covers @1-devices / @2-devices tests; use
+ *     `--devices-per-worker 4` to include the @3-devices / @4-devices tests (i.e. the full suite).
+ *     Total simulators created = workers x devices-per-worker.
+ *   - Simulators are created shut down; `global-setup.ts` then pre-boots the pool, pre-installs the
+ *     app and starts a WebDriverAgent per simulator before any test runs.
+ *   - Prefer `--workers 1`. Each booted simulator spawns ~280 host processes, so more workers
+ *     saturate the machine and produce timeout failures unrelated to the app — see CLAUDE.md.
  *   - Total simulators (workers * devices) must not exceed 12 (the IOS_N_SIMULATOR cap).
  *   - Creating simulators has a one-off cost (clone + media). For fast iteration, run once with
  *     `--keep`, paste the printed IOS_N_SIMULATOR lines into .env, then use `pnpm test-ios`.
@@ -57,7 +63,7 @@ const MAX_SIMULATORS = 12;
 
 type ParsedArgs = {
   workers: number;
-  devicesPerTest: number;
+  devicesPerWorker: number;
   grep: string;
   keep: boolean;
   runtime?: string;
@@ -68,7 +74,7 @@ type ParsedArgs = {
 function parseArgs(argv: string[]): ParsedArgs {
   const args: ParsedArgs = {
     workers: 2,
-    devicesPerTest: 2,
+    devicesPerWorker: 2,
     grep: '@ios',
     keep: false,
     passthrough: [],
@@ -98,9 +104,9 @@ function parseArgs(argv: string[]): ParsedArgs {
       const [value, consumedNext] = readValue(arg, ownArgs[i + 1]);
       args.workers = parseInt(value);
       if (consumedNext) i++;
-    } else if (arg.startsWith('--devices')) {
+    } else if (arg.startsWith('--devices-per-worker')) {
       const [value, consumedNext] = readValue(arg, ownArgs[i + 1]);
-      args.devicesPerTest = parseInt(value);
+      args.devicesPerWorker = parseInt(value);
       if (consumedNext) i++;
     } else if (arg.startsWith('--grep')) {
       const [value, consumedNext] = readValue(arg, ownArgs[i + 1]);
@@ -138,15 +144,16 @@ function validate(args: ParsedArgs): number {
     console.error(`Invalid --workers value: ${args.workers}`);
     process.exit(1);
   }
-  if (isNaN(args.devicesPerTest) || args.devicesPerTest < 1) {
-    console.error(`Invalid --devices value: ${args.devicesPerTest}`);
+  if (isNaN(args.devicesPerWorker) || args.devicesPerWorker < 1) {
+    console.error(`Invalid --devices-per-worker value: ${args.devicesPerWorker}`);
     process.exit(1);
   }
-  const totalSimulators = args.workers * args.devicesPerTest;
+  const totalSimulators = args.workers * args.devicesPerWorker;
   if (totalSimulators > MAX_SIMULATORS) {
     console.error(
-      `Requested ${args.workers} workers x ${args.devicesPerTest} devices = ${totalSimulators} ` +
-        `simulators, but the maximum is ${MAX_SIMULATORS}. Lower --workers or --devices.`
+      `Requested ${args.workers} workers x ${args.devicesPerWorker} devices-per-worker = ` +
+        `${totalSimulators} simulators, but the maximum is ${MAX_SIMULATORS}. ` +
+        `Lower --workers or --devices-per-worker.`
     );
     process.exit(1);
   }
@@ -166,9 +173,14 @@ function main(): void {
   const args = parseArgs(process.argv.slice(2));
   const totalSimulators = validate(args);
 
+  // Build the WebDriverAgent runner once up front so the driver reuses it across every simulator
+  // instead of building/launching WDA per session (the slowest, flakiest part of a cold-sim
+  // startup). No-op once built — see scripts/build_wda.ts.
+  ensureWdaBuilt();
+
   console.log(
     `\nProvisioning ${totalSimulators} simulator(s) for ${args.workers} worker(s) ` +
-      `x ${args.devicesPerTest} device(s)...`
+      `x ${args.devicesPerWorker} device(s) per worker...`
   );
 
   const deviceConfig = resolveDeviceConfig({ runtime: args.runtime });
@@ -183,7 +195,7 @@ function main(): void {
   });
   childEnv.PLATFORM = 'ios';
   childEnv.PLAYWRIGHT_WORKERS_COUNT_IOS = String(args.workers);
-  childEnv.DEVICES_PER_TEST_COUNT = String(args.devicesPerTest);
+  childEnv.DEVICES_PER_TEST_COUNT = String(args.devicesPerWorker);
   childEnv._TESTING = childEnv._TESTING ?? '1';
   // Service network selection (mainnet default). Devnet also needs DEVNET_* vars in .env — see
   // capabilities_ios.ts / .env.sample. Left unset here so .env's NETWORK_TARGET is respected.

--- a/scripts/run_ios_parallel.ts
+++ b/scripts/run_ios_parallel.ts
@@ -6,7 +6,6 @@ import {
   type IosServiceNetwork,
   type Simulator,
 } from '../run/test/utils/capabilities_ios';
-
 import { ensureWdaBuilt } from './build_wda';
 import { createIOSSimulators, resolveDeviceConfig } from './create_ios_simulators';
 import { deleteSimulators } from './ios_shared';


### PR DESCRIPTION
Speeds up the mobile suite, primarily iOS, and fixes flakiness found along the way.

## Simulator boot / setup

Boot, app install and WebDriverAgent startup were each paid inside the first test to touch a device, with WDA startup serialised by a lock in the driver. `global-setup` now does all three up front and sessions attach via `appium:webDriverAgentUrl`.

**3-device spec 42.1s → 34.0s. Cold start 205.5s → 130.0s.** Runs on CI unchanged.

⚠️ **BREAKING:** `run_ios_parallel --devices` → `--devices-per-worker`. The value is a per-worker pool, and `--devices 1` creating two simulators was confusing. The old flag errors.

## 10s disappearing timer on devnet

These specs wait out the timer for real, so it floors their runtime — the slowest group at 24% of a full run. 30s exists for mainnet latency; a local devnet doesn't need it. `getDisappearingTestTiming()` picks per-network, and specs that deliberately chose longer pass that as their fallback, so **mainnet is unchanged**.

`hasElementDisappeared` gains an optional `expectedDuration` — the "disappeared too early" floor was inferred from `maxWait`, which is fine at 30s but rejects correct runs at 10s.

**18 specs, ~410s off a devnet run.**

## Stop paying fixed waits that polling already covers

`verifyElementNotPresent` sleeps its full `maxWait` before checking, costing 2s per call regardless. 31 sites that only assert "gone by now" now poll instead; sites asserting "must stay absent for a window" keep the sleep, since that window is the assertion. Plus 25 `sleepFor` calls sitting in front of something that already waited, and several large probes paid in full on the common path.

## Linked-device deletion races

`hasElementBeenDeleted` requires the element to be found *before* it goes — on a linked device the sync can win that race, failing the test because the app was fast. `Delete conversation from conversation list` failed ~1/3 this way.

Four specs already assert presence before triggering the delete, so they now only watch it go — same assertion, split across two steps, with the "appears" half where nothing can race it. `Block user linked device` gains a presence check it never had.

## Linked-device onboarding noise

- **Late permission prompts** cover the home screen and every later step fails against a screen it can't reach, never mentioning permissions. Window widened 2s→5s, plus a recovery check — 5s alone isn't sufficient, a full probe was still seen missing it. **2 failures in 12 runs before, 0 in 18 after.**
- **WDA idle waits**: a disappearing countdown repaints every second so the app never goes idle; single `findElements` calls measured at 21s and 60s. `waitForIdleTimeout` bounds the wait rather than removing it, at no measured cost.
- **`Disappear after send off 1:1`** never waits for expiry, but the control message it checks is itself subject to the timer — so a short duration raced the assertion. Now uses one that outlives the test; config-sync coverage unchanged.
- **`openConversation`** taps, then confirms the header. An XCUITest element handle is a path into the hierarchy, so a list re-ordering between resolve and click lands the tap elsewhere, silently.