### PR TITLE
perf(tests): run iOS tests in tiered passes by device count

### DIFF
--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -183,15 +183,51 @@ jobs:
           RISK: ${{ github.event.inputs.RISK }}
           PRO_GREP_INVERT: ${{ env.PRO_GREP_INVERT }}
 
-      - name: Run the iOS tests​​ (all device counts)
+      - name: Run the iOS tests​​ (tiered by device count)
         env:
-          DEVICES_PER_TEST_COUNT: 4
           _TESTING: ${{ env._TESTING }}
           PRINT_FAILED_TEST_LOGS: ${{ env.PRINT_FAILED_TEST_LOGS }}
           PRINT_ONGOING_TEST_LOGS: ${{ env.PRINT_ONGOING_TEST_LOGS }}
+          PARALLEL_TIER: ci
         run: |
-          pwd
-          npx playwright test --grep "(?=.*@${PLATFORM})(?=.*@${{ github.event.inputs.RISK }})" $PRO_GREP_INVERT #Note: this has to be double quotes
+          # One Playwright invocation per device class, driven by run/constants/parallelism.ts so the
+          # worker counts live in one place rather than being duplicated here.
+          #
+          # Why not a single run: DEVICES_PER_TEST_COUNT is one global per invocation, so a single run
+          # must size every worker's pool for the largest spec — a @1-devices spec then occupies a
+          # worker holding 4 simulators and using 1. Passes run in sequence, so the simulator draw is
+          # the largest pass, not the sum.
+          #
+          # Allure results accumulate across invocations (the reporter does not clear resultsDir), so
+          # the report step below still sees one merged run.
+          set -uo pipefail
+
+          PASSES="$(npx --yes ts-node scripts/print_tier.ts "$PARALLEL_TIER")"
+          # An empty table would otherwise run zero tests and report success.
+          if [ -z "$PASSES" ]; then
+            echo "::error::print_tier.ts produced no passes for tier '$PARALLEL_TIER'"
+            exit 1
+          fi
+          echo "Tier '$PARALLEL_TIER' passes (devices workers):"
+          echo "$PASSES"
+
+          overall=0
+          while read -r DEVICES WORKERS; do
+            [ -n "$DEVICES" ] || continue
+            echo "::group::@${DEVICES}-devices x${WORKERS} worker(s) ($((DEVICES * WORKERS)) simulators)"
+            # --pass-with-no-tests: a RISK filter can legitimately empty one device class while the
+            # others still have work, and that must not fail the run.
+            DEVICES_PER_TEST_COUNT="$DEVICES" \
+            PLAYWRIGHT_WORKERS_COUNT_IOS="$WORKERS" \
+            npx playwright test \
+              --grep "(?=.*@${PLATFORM})(?=.*@${{ github.event.inputs.RISK }})(?=.*@${DEVICES}-devices)" \
+              --pass-with-no-tests \
+              $PRO_GREP_INVERT || overall=1
+            echo "::endgroup::"
+          done <<< "$PASSES"
+
+          # Every pass runs even if an earlier one failed, so the report covers the whole suite.
+          exit $overall
 
       - name: Generate and publish test report
         uses: ./github/actions/generate-publish-test-report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,13 +99,39 @@ simulators make the whole step a no-op, so back-to-back runs skip it.
 > (`simctl launch` needs a booted device) and uses `simctl bootstatus -b`, which waits for boot to
 > genuinely finish. If CI becomes flaky at startup, this block is the first thing to revert.
 
-> **Stay at 1 worker locally.** Each booted simulator spawns **~280 host processes** — 6 sims took a
-> 14-core Mac to a load average of ~500 and caused specs to fail on timeouts that had nothing to do
-> with the app (they passed immediately at 1 worker). Parallelism *works* (workers get correctly
-> offset device pools), but the host, not the harness, is the bottleneck: throughput barely improves
-> and false failures become indistinguishable from real ones. `global-setup.ts` prints a warning
-> when `workers > 1`. If you must parallelise, use 2 workers × 2 devices (same total sim count)
-> restricted to `@1-devices`/`@2-devices` specs.
+### Parallelism
+
+Use `pnpm test-ios-parallel --tier standard` (6 simulators). Tiers live in
+`run/constants/parallelism.ts`, which both the local runner and CI read — `--list-tiers` prints them.
+
+`DEVICES_PER_TEST_COUNT` is one global per Playwright invocation, so a single run has to size *every*
+worker's pool for the largest spec: at `D=4` a `@1-devices` spec occupies a worker holding four
+simulators and using one. So parallelism is expressed as one invocation **per device class**, run in
+sequence — which means the simulator draw is the largest pass, not the sum.
+
+Measured 2026-07-30 (`--shard=1/4`, no `@pro`, 14-core Apple Silicon, on a build carrying the
+SnodePool use-after-free fix — 9 configs, 39 min, zero crashes):
+
+| specs | W=1 | W=2 | W=3 | W=4 |
+|---|---|---|---|---|
+| `@1-devices` | 271s | 133s (2.04×) | 105s (2.58×) | 90s (3.01×) |
+| `@2-devices` | 549s | 295s (1.86×) | 226s (2.43×) | — |
+| `@3-devices` | 427s | 227s (1.88×) | — | — |
+
+`standard` totals 543s against 1247s all-serial (**2.30×**). `@4-devices` is unmeasured and gets no
+parallelism below 8 simulators; nothing above W=4 is measured on any host.
+
+> **This supersedes earlier "stay at 1 worker" guidance.** That note reported 6 simulators taking a
+> 14-core Mac to a load average of ~500 with timeout failures unrelated to the app. Both 6-simulator
+> configurations above now run clean, and `@3-devices` at W=2 was the only configuration in the matrix
+> with zero test failures. Two things changed in between: the specs were hardened (several races
+> fixed), and a libsession use-after-free was crashing the app ~1s after launch, which inflated
+> baselines and produced failures that looked like host saturation. `global-setup.ts` still warns when
+> `workers > 1`; that warning is now stale for tiered runs.
+>
+> The underlying constraint is real, though — each booted simulator is **~280 host processes**, and an
+> over-subscribed host fails with timeouts indistinguishable from product bugs. Raise a tier only
+> after measuring it on the hardware in question.
 
 ## Running tests
 
@@ -118,7 +144,13 @@ pnpm test-one '<title> @ios'     # one spec, constrained to a platform
 pnpm test-one-logs '<title>'     # one spec with full device logs
 pnpm test-no-retry '<grep>'      # retries disabled
 pnpm test-high-risk-ios          # --grep '@ios @high-risk'
+
+pnpm test-ios-parallel --tier standard   # tiered, 6 sims — fastest full-suite local run
+pnpm test-ios-parallel --list-tiers      # tiers, their cost and their passes
 ```
+
+`--tier` provisions throwaway simulators and runs one pass per device class; a `--grep` alongside it
+narrows every pass rather than replacing the device-class filter. See **Parallelism** above.
 
 ### How tags work
 
@@ -148,10 +180,17 @@ an existing spec (e.g. `run/test/specs/app_disguise_icons.spec.ts`).
 
 ## CI vs local
 
-CI (`.github/workflows/ios-regression.yml`) runs on a **self-hosted macOS** runner with
-`CI=1`, `PLAYWRIGHT_WORKERS_COUNT_IOS=3`, `DEVICES_PER_TEST_COUNT=4` (→ 12 simulators from
-`ci-simulators.json`), and `IOS_APP_PATH_PREFIX` pointing at an extracted `Session.app`.
-Locally, simulators come from `.env` (`IOS_N_SIMULATOR`) instead of `ci-simulators.json`.
+CI (`.github/workflows/ios-regression.yml`) runs on a **self-hosted macOS** runner with `CI=1`, 12
+simulators from `ci-simulators.json`, and `IOS_APP_PATH_PREFIX` pointing at an extracted
+`Session.app`. Locally, simulators come from `.env` (`IOS_N_SIMULATOR`) instead.
+
+The run step is **tiered** like the local runner: it shells out to `scripts/print_tier.ts ci` and
+does one `npx playwright test` per device class, setting `DEVICES_PER_TEST_COUNT` and
+`PLAYWRIGHT_WORKERS_COUNT_IOS` per pass, so the worker counts are not duplicated in YAML. Every pass
+runs even if an earlier one fails (the step still exits non-zero), and Allure results accumulate
+across invocations because the reporter does not clear `resultsDir` — so the report step still sees
+one merged run. The `ci` tier is deliberately **not** maximum utilisation: its worker counts above 4
+are extrapolated, not measured on the runner.
 
 Device allocation is the **same code path** locally and on CI: `openiOSApp` (in
 `open_app.ts`) always offsets each worker's device pool by its parallel index
@@ -159,9 +198,15 @@ Device allocation is the **same code path** locally and on CI: `openiOSApp` (in
 single worker (the local default) this simply collapses to devices `0..N-1`; with more
 workers it fans out (worker 0: devices 0–3, worker 1: 4–7, …), so N workers need
 `N * DEVICES_PER_TEST_COUNT` simulators. To run multi-worker locally, use
-`pnpm test-ios-parallel` (`scripts/run_ios_parallel.ts`), which provisions exactly that many
-throwaway simulators and wires their UDIDs into the run. Keep this in mind when editing
-`capabilities_ios.ts` / `open_app.ts`.
+`pnpm test-ios-parallel --tier standard` (`scripts/run_ios_parallel.ts`), which provisions exactly
+the simulators the tier's largest pass needs and wires their UDIDs into the run. Keep this in mind
+when editing `capabilities_ios.ts` / `open_app.ts`.
+
+Note this pool is **per worker and uniform** — there is no way to give one worker 4 devices and
+another 2 in the same invocation, which is why tiering is sequential passes rather than a mixed run.
+Making it mixed would mean replacing the offset with a shared pool that specs check out from, which
+introduces a deadlock (two workers holding 3 of 6 simulators, both wanting 4) that the current design
+cannot hit.
 
 ## Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,8 +189,10 @@ does one `npx playwright test` per device class, setting `DEVICES_PER_TEST_COUNT
 `PLAYWRIGHT_WORKERS_COUNT_IOS` per pass, so the worker counts are not duplicated in YAML. Every pass
 runs even if an earlier one fails (the step still exits non-zero), and Allure results accumulate
 across invocations because the reporter does not clear `resultsDir` — so the report step still sees
-one merged run. The `ci` tier is deliberately **not** maximum utilisation: its worker counts above 4
-are extrapolated, not measured on the runner.
+one merged run. Every pass in the `ci` tier fills the 12-simulator pool — a pass boots only
+`workers × devices`, so the run's peak draw is 12 regardless and holding one lower would idle
+simulators without lowering the ceiling. Its worker counts above 4 are extrapolated, not measured on
+the runner, so the first run on it is a measurement.
 
 Device allocation is the **same code path** locally and on CI: `openiOSApp` (in
 `open_app.ts`) always offsets each worker's device pool by its parallel index

--- a/run/constants/parallelism.ts
+++ b/run/constants/parallelism.ts
@@ -1,0 +1,116 @@
+/**
+ * Simulator-parallelism tiers.
+ *
+ * A Playwright worker owns a *fixed* pool of `DEVICES_PER_TEST_COUNT` simulators (see `openiOSApp`
+ * in open_app.ts, which offsets each worker's pool by its parallel index). That count is a single
+ * global per invocation, so one run cannot give worker 0 four devices and worker 1 two. Sizing it to
+ * the largest spec — what CI does today with `DEVICES_PER_TEST_COUNT: 4` — means a `@1-devices` spec
+ * occupies a worker holding four simulators and using one.
+ *
+ * So parallelism is expressed as a series of *passes*: one Playwright invocation per device class,
+ * each with its own devices-per-worker and worker count, filtered with `--grep '@N-devices'`. Passes
+ * run sequentially, so the simulator draw is the max across passes rather than the sum.
+ *
+ * MEASUREMENT PROVENANCE — 2026-07-30, `--shard=1/4 --grep-invert @pro`, on a 14-core Apple Silicon
+ * host, against a build with the SnodePool use-after-free fix (9 configs, 39 min, zero crashes):
+ *
+ *   tier        W=1     W=2            W=3            W=4
+ *   @1-devices  271s    133s (2.04x)   105s (2.58x)   90s (3.01x)
+ *   @2-devices  549s    295s (1.86x)   226s (2.43x)   —
+ *   @3-devices  427s    227s (1.88x)   —              —
+ *
+ * Caveats that matter when tuning these numbers:
+ *   - `@4-devices` was never measured. It gets no parallelism below 8 simulators, and those are the
+ *     slowest specs in the suite.
+ *   - Nothing above W=4 was measured anywhere, on any host.
+ *   - Those walls include failing specs, whose timings are not comparable to passing ones.
+ *   - Measured on one shard of one host. CI hardware differs, so treat CI numbers as a starting
+ *     point to measure from, not as findings.
+ *
+ * Over-subscribing is not a soft failure: each booted simulator spawns ~280 host processes, and a
+ * saturated host produces timeouts that look exactly like product bugs. Prefer raising a tier only
+ * after measuring it on the hardware in question.
+ */
+
+export type ParallelPass = {
+  /**
+   * Device count for this pass. Doubles as `DEVICES_PER_TEST_COUNT` and as the `@N-devices` tag
+   * that selects the specs, so the pool size and the spec filter cannot drift apart.
+   */
+  devices: number;
+  /** Playwright workers for this pass. Simulators used = `devices * workers`. */
+  workers: number;
+};
+
+export type ParallelTier = {
+  /** Shown by `--tier` / `--list-tiers`; keep it short, it is user-facing. */
+  summary: string;
+  passes: ParallelPass[];
+};
+
+export const PARALLEL_TIERS = {
+  /**
+   * 4 simulators. The lowest tier worth running: `@1-devices` still parallelises well, but
+   * `@3-devices` and `@4-devices` stay serial because they cannot fit two workers into four sims.
+   * Measured 812s vs 1247s all-serial on the reference shard (1.54x).
+   */
+  conservative: {
+    summary: '4 simulators — safest; 3- and 4-device specs stay serial',
+    passes: [
+      { devices: 1, workers: 4 },
+      { devices: 2, workers: 2 },
+      { devices: 3, workers: 1 },
+      { devices: 4, workers: 1 },
+    ],
+  },
+
+  /**
+   * 6 simulators. Every measured pass at its best measured setting. Both 6-simulator configurations
+   * ran clean, and `@3-devices` at W=2 was the only configuration in the matrix with zero test
+   * failures. Measured 543s vs 1247s all-serial on the reference shard (2.30x).
+   */
+  standard: {
+    summary: '6 simulators — best measured local throughput',
+    passes: [
+      { devices: 1, workers: 4 },
+      { devices: 2, workers: 3 },
+      { devices: 3, workers: 2 },
+      { devices: 4, workers: 1 },
+    ],
+  },
+
+  /**
+   * 12 simulators, the `IOS_N_SIMULATOR` / ci-simulators.json cap.
+   *
+   * Deliberately NOT the maximum utilisation the pool allows (that would be W=12 / W=6 / W=4 / W=3).
+   * Every worker count here above 4 is extrapolated, and the failure mode of an over-subscribed
+   * runner is false failures indistinguishable from real ones — the exact problem the old
+   * "stay at 1 worker" guidance was written to avoid. Raise these once measured ON the runner.
+   */
+  ci: {
+    summary: '12 simulators — conservative starting point for the self-hosted runner',
+    passes: [
+      { devices: 1, workers: 6 },
+      { devices: 2, workers: 6 },
+      { devices: 3, workers: 4 },
+      { devices: 4, workers: 3 },
+    ],
+  },
+} as const satisfies Record<string, ParallelTier>;
+
+export type ParallelTierName = keyof typeof PARALLEL_TIERS;
+
+export const PARALLEL_TIER_NAMES = Object.keys(PARALLEL_TIERS) as ParallelTierName[];
+
+/** Simulators a tier needs: the largest single pass, since passes run one after another. */
+export function simulatorsRequired(tier: ParallelTier): number {
+  return Math.max(...tier.passes.map(p => p.devices * p.workers));
+}
+
+/**
+ * `--grep` for one pass: the platform and device-count tags ANDed via lookaheads, so it composes
+ * with any additional filter (risk, `--grep-invert @pro`) the caller already applies.
+ */
+export function passGrep(pass: ParallelPass, platform: 'android' | 'ios' = 'ios'): string {
+  return `(?=.*@${platform})(?=.*@${pass.devices}-devices)`;
+}

--- a/run/constants/parallelism.ts
+++ b/run/constants/parallelism.ts
@@ -80,17 +80,21 @@ export const PARALLEL_TIERS = {
   },
 
   /**
-   * 12 simulators, the `IOS_N_SIMULATOR` / ci-simulators.json cap.
+   * 12 simulators, the `IOS_N_SIMULATOR` / ci-simulators.json cap. Every pass fills the pool.
    *
-   * Deliberately NOT the maximum utilisation the pool allows (that would be W=12 / W=6 / W=4 / W=3).
-   * Every worker count here above 4 is extrapolated, and the failure mode of an over-subscribed
-   * runner is false failures indistinguishable from real ones — the exact problem the old
-   * "stay at 1 worker" guidance was written to avoid. Raise these once measured ON the runner.
+   * A pass boots only `workers × devices` simulators (see global-setup.ts), so the run's peak draw is
+   * 12 whichever pass is running. Holding one below that leaves simulators idle without lowering the
+   * ceiling, which is why the `@1-devices` pass takes 12 workers rather than fewer.
+   *
+   * The worker counts above 4 are extrapolated — nothing above W=4 has been measured on any host —
+   * and an over-subscribed runner fails in a way indistinguishable from real test failures, the exact
+   * problem the old "stay at 1 worker" guidance was written to avoid. Treat the first run on this tier
+   * as a measurement, and lower these before concluding a flake is the app's fault.
    */
   ci: {
-    summary: '12 simulators — conservative starting point for the self-hosted runner',
+    summary: '12 simulators — fills the CI pool; worker counts above 4 are unmeasured',
     passes: [
-      { devices: 1, workers: 6 },
+      { devices: 1, workers: 12 },
       { devices: 2, workers: 6 },
       { devices: 3, workers: 4 },
       { devices: 4, workers: 3 },

--- a/scripts/print_tier.ts
+++ b/scripts/print_tier.ts
@@ -1,0 +1,45 @@
+/**
+ * Emits a parallelism tier as plain text so CI can drive its passes from the same table the local
+ * runner uses, instead of a second copy of the numbers living in YAML.
+ *
+ * Usage:
+ *   npx ts-node scripts/print_tier.ts ci           # one "<devices> <workers>" line per pass
+ *   npx ts-node scripts/print_tier.ts ci --sims    # simulators the tier needs (largest pass)
+ *
+ * Intentionally imports nothing but the tier table: modules such as capabilities_ios log banners on
+ * import, and anything on stdout here would be parsed as data by the caller.
+ */
+import {
+  PARALLEL_TIER_NAMES,
+  PARALLEL_TIERS,
+  type ParallelTierName,
+  simulatorsRequired,
+} from '../run/constants/parallelism';
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const name = argv.find(a => !a.startsWith('--'));
+  const wantSims = argv.includes('--sims');
+
+  if (!name || !PARALLEL_TIER_NAMES.includes(name as ParallelTierName)) {
+    // stderr, so a caller capturing stdout gets nothing rather than an error string as data.
+    console.error(
+      `Usage: print_tier.ts <${PARALLEL_TIER_NAMES.join('|')}> [--sims]\n` +
+        (name ? `Unknown tier "${name}".` : 'No tier given.')
+    );
+    process.exit(1);
+  }
+
+  const tier = PARALLEL_TIERS[name as ParallelTierName];
+
+  if (wantSims) {
+    console.log(String(simulatorsRequired(tier)));
+    return;
+  }
+
+  for (const pass of tier.passes) {
+    console.log(`${pass.devices} ${pass.workers}`);
+  }
+}
+
+main();

--- a/scripts/run_ios_parallel.ts
+++ b/scripts/run_ios_parallel.ts
@@ -2,6 +2,14 @@ import { spawn } from 'child_process';
 import dotenv from 'dotenv';
 
 import {
+  PARALLEL_TIER_NAMES,
+  PARALLEL_TIERS,
+  type ParallelPass,
+  type ParallelTierName,
+  passGrep,
+  simulatorsRequired,
+} from '../run/constants/parallelism';
+import {
   ALLOWED_IOS_NETWORKS,
   type IosServiceNetwork,
   type Simulator,
@@ -25,6 +33,8 @@ import { deleteSimulators } from './ios_shared';
  * environment (without touching your .env), and cleans up after itself.
  *
  * Usage:
+ *   pnpm test-ios-parallel --tier standard          # tiered: one pass per device class (recommended)
+ *   pnpm test-ios-parallel --list-tiers             # show the tiers and what they cost
  *   pnpm test-ios-parallel                                      # 2 workers x 2 devices (4 sims), grep @ios
  *   pnpm test-ios-parallel --devices-per-worker 4               # 2 workers x 4 devices (8 sims)
  *   pnpm test-ios-parallel --workers 3 --devices-per-worker 4   # 3 workers x 4 devices (12 sims)
@@ -42,6 +52,15 @@ import { deleteSimulators } from './ios_shared';
  *   - `--runtime` picks the iOS simulator runtime (a version like "26.1" or a full identifier).
  *     If omitted, the preferred runtime is used when installed, otherwise the newest installed
  *     iOS runtime. Device type is overridable via the IOS_SIM_DEVICE_TYPE env var.
+ *   - `--tier` runs one Playwright invocation per device class (see run/constants/parallelism.ts),
+ *     each with its own devices-per-worker and worker count. This exists because
+ *     `DEVICES_PER_TEST_COUNT` is a single global per invocation, so a single run has to size its
+ *     pools for the largest spec and wastes simulators on every smaller one. Passes run in sequence,
+ *     so the pool is the largest pass, not the sum. `--tier` replaces `--workers` /
+ *     `--devices-per-worker`; combining them is rejected. A `--grep` given alongside `--tier` is
+ *     ANDed in as an extra lookahead on top of the pass's own platform/device-count filter.
+ *     A failing pass does not stop the remaining passes — you get the whole picture, and the exit
+ *     status is non-zero if any pass failed.
  *   - `--devices-per-worker` is the per-worker simulator pool. It must be >=
  *     the largest test's device count in your grep, otherwise those tests fail fast with a clear
  *     error (see openiOSApp). The default of 2 covers @1-devices / @2-devices tests; use
@@ -60,11 +79,17 @@ dotenv.config({ quiet: true });
 
 const MAX_SIMULATORS = 12;
 
+const DEFAULT_GREP = '@ios';
+
 type ParsedArgs = {
   workers: number;
   devicesPerWorker: number;
   grep: string;
   keep: boolean;
+  tier?: ParallelTierName;
+  listTiers: boolean;
+  /** Set when the caller passed --workers/--devices-per-worker, so --tier can reject the combination. */
+  explicitPools: boolean;
   runtime?: string;
   network?: string;
   passthrough: string[];
@@ -74,8 +99,10 @@ function parseArgs(argv: string[]): ParsedArgs {
   const args: ParsedArgs = {
     workers: 2,
     devicesPerWorker: 2,
-    grep: '@ios',
+    grep: DEFAULT_GREP,
     keep: false,
+    listTiers: false,
+    explicitPools: false,
     passthrough: [],
   };
 
@@ -99,13 +126,25 @@ function parseArgs(argv: string[]): ParsedArgs {
     const arg = ownArgs[i];
     if (arg === '--keep') {
       args.keep = true;
+    } else if (arg === '--list-tiers') {
+      args.listTiers = true;
+    } else if (arg.startsWith('--tier')) {
+      const [value, consumedNext] = readValue(arg, ownArgs[i + 1]);
+      if (!PARALLEL_TIER_NAMES.includes(value as ParallelTierName)) {
+        console.error(`Invalid --tier "${value}". Use ${PARALLEL_TIER_NAMES.join(' | ')}.`);
+        process.exit(1);
+      }
+      args.tier = value as ParallelTierName;
+      if (consumedNext) i++;
     } else if (arg.startsWith('--workers')) {
       const [value, consumedNext] = readValue(arg, ownArgs[i + 1]);
       args.workers = parseInt(value);
+      args.explicitPools = true;
       if (consumedNext) i++;
     } else if (arg.startsWith('--devices-per-worker')) {
       const [value, consumedNext] = readValue(arg, ownArgs[i + 1]);
       args.devicesPerWorker = parseInt(value);
+      args.explicitPools = true;
       if (consumedNext) i++;
     } else if (arg.startsWith('--grep')) {
       const [value, consumedNext] = readValue(arg, ownArgs[i + 1]);
@@ -139,6 +178,23 @@ function validate(args: ParsedArgs): number {
     console.error(`Invalid --network "${args.network}". Use ${ALLOWED_IOS_NETWORKS.join(' | ')}.`);
     process.exit(1);
   }
+  if (args.tier) {
+    if (args.explicitPools) {
+      console.error(
+        `--tier sets devices-per-worker and workers per pass, so it cannot be combined with ` +
+          `--workers / --devices-per-worker. Drop one or the other.`
+      );
+      process.exit(1);
+    }
+    const needed = simulatorsRequired(PARALLEL_TIERS[args.tier]);
+    if (needed > MAX_SIMULATORS) {
+      console.error(
+        `Tier "${args.tier}" needs ${needed} simulators, but the maximum is ${MAX_SIMULATORS}.`
+      );
+      process.exit(1);
+    }
+    return needed;
+  }
   if (isNaN(args.workers) || args.workers < 1) {
     console.error(`Invalid --workers value: ${args.workers}`);
     process.exit(1);
@@ -168,8 +224,66 @@ function printKeepInfo(simulators: Simulator[]): void {
   console.log('`xcrun simctl delete <udid>`.\n');
 }
 
-function main(): void {
+function printTiers(): void {
+  console.log('\nAvailable tiers (see run/constants/parallelism.ts for the measurements):\n');
+  for (const name of PARALLEL_TIER_NAMES) {
+    const tier = PARALLEL_TIERS[name];
+    console.log(`  ${name} — ${tier.summary}`);
+    console.log(`    simulators needed: ${simulatorsRequired(tier)}`);
+    for (const pass of tier.passes) {
+      console.log(
+        `      @${pass.devices}-devices  x${pass.workers} worker(s)  ` +
+          `(${pass.devices * pass.workers} sims)`
+      );
+    }
+    console.log('');
+  }
+}
+
+/** Runs one Playwright invocation to completion and resolves with its exit status. */
+function runPlaywright(playwrightArgs: string[], env: NodeJS.ProcessEnv): Promise<number> {
+  return new Promise((resolve, reject) => {
+    console.log(`\nRunning: npx ${playwrightArgs.join(' ')}\n`);
+    const child = spawn('npx', playwrightArgs, { stdio: 'inherit', env });
+
+    // Attached per invocation and detached on exit. A tiered run spawns one child per pass, so
+    // leaving these registered would leak listeners and signal already-dead children.
+    const forward = (signal: NodeJS.Signals) => () => child.kill(signal);
+    const onInt = forward('SIGINT');
+    const onTerm = forward('SIGTERM');
+    process.on('SIGINT', onInt);
+    process.on('SIGTERM', onTerm);
+    const detach = () => {
+      process.off('SIGINT', onInt);
+      process.off('SIGTERM', onTerm);
+    };
+
+    child.on('error', err => {
+      detach();
+      reject(err);
+    });
+    child.on('exit', (code, signal) => {
+      detach();
+      resolve(code ?? (signal ? 1 : 0));
+    });
+  });
+}
+
+function printTierSummary(name: string, results: { pass: ParallelPass; code: number }[]): void {
+  console.log(`\n=== tier "${name}" summary ===`);
+  for (const { pass, code } of results) {
+    const status = code === 0 ? 'pass' : `FAILED (exit ${code})`;
+    console.log(`  @${pass.devices}-devices x${pass.workers} worker(s): ${status}`);
+  }
+  console.log('');
+}
+
+async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  if (args.listTiers) {
+    printTiers();
+    return;
+  }
   const totalSimulators = validate(args);
 
   // Build the WebDriverAgent runner once up front so the driver reuses it across every simulator
@@ -217,27 +331,62 @@ function main(): void {
     console.log(`✓ Deleted ${deleted} simulator(s)`);
   };
 
-  const playwrightArgs = ['playwright', 'test', '--grep', args.grep, ...args.passthrough];
-  console.log(`\nRunning: npx ${playwrightArgs.join(' ')}\n`);
+  try {
+    if (args.tier) {
+      const tier = PARALLEL_TIERS[args.tier];
+      const results: { pass: ParallelPass; code: number }[] = [];
 
-  const child = spawn('npx', playwrightArgs, { stdio: 'inherit', env: childEnv });
+      for (const pass of tier.passes) {
+        // The pass owns the platform and device-count filter; a caller-supplied --grep is ANDed on
+        // top as a further lookahead rather than replacing it, so `--grep '@ios @high-risk'` narrows
+        // each pass instead of selecting the wrong device class.
+        const grep =
+          args.grep === DEFAULT_GREP ? passGrep(pass) : `${passGrep(pass)}(?=.*${args.grep})`;
 
-  // Forward interrupts to the child; its 'exit' below then triggers cleanup exactly once.
-  const forward = (signal: NodeJS.Signals) => () => child.kill(signal);
-  process.on('SIGINT', forward('SIGINT'));
-  process.on('SIGTERM', forward('SIGTERM'));
+        console.log(
+          `\n=== tier "${args.tier}": @${pass.devices}-devices, ${pass.workers} worker(s), ` +
+            `${pass.devices * pass.workers} simulator(s) ===`
+        );
 
-  child.on('error', err => {
+        const code = await runPlaywright(
+          [
+            'playwright',
+            'test',
+            '--grep',
+            grep,
+            // An empty pass is not a failure: an extra --grep can legitimately clear one device
+            // class while the others still have work to do.
+            '--pass-with-no-tests',
+            ...args.passthrough,
+          ],
+          {
+            ...childEnv,
+            DEVICES_PER_TEST_COUNT: String(pass.devices),
+            PLAYWRIGHT_WORKERS_COUNT_IOS: String(pass.workers),
+          }
+        );
+        // Deliberately not bailing on the first failure — a regression run is worth completing so
+        // you see every device class, not just up to the first one that broke.
+        results.push({ pass, code });
+      }
+
+      printTierSummary(args.tier, results);
+      cleanup();
+      process.exit(results.some(r => r.code !== 0) ? 1 : 0);
+    }
+
+    const code = await runPlaywright(
+      ['playwright', 'test', '--grep', args.grep, ...args.passthrough],
+      childEnv
+    );
+    cleanup();
+    // Preserve the child's exit status so CI/other callers see the real result.
+    process.exit(code);
+  } catch (err) {
     console.error('Failed to start Playwright:', err);
     cleanup();
     process.exit(1);
-  });
-
-  child.on('exit', (code, signal) => {
-    cleanup();
-    // Preserve the child's exit status so CI/other callers see the real result.
-    process.exit(code ?? (signal ? 1 : 0));
-  });
+  }
 }
 
-main();
+void main();


### PR DESCRIPTION
DEVICES_PER_TEST_COUNT is a single global per Playwright invocation, so every worker sized its simulator pool for the largest spec in the run: a @1-devices spec occupied a worker holding four simulators and using one.

iOS runs now execute one invocation per device class, each with its own devices-per-worker and worker count, from a shared tier table. Passes run in sequence, so the simulator draw is the largest pass rather than the sum.

Locally `pnpm test-ios-parallel --tier standard` runs the suite across six simulators. On CI the single test step becomes one pass per device class reading the same table; every pass runs even if an earlier one fails, the step still exits non-zero, and Allure results accumulate across invocations into one report.