### PR TITLE
feat(devnet): resolve local file server and SOGS alongside the devnet

### DIFF
--- a/.github/workflows/android-regression.yml
+++ b/.github/workflows/android-regression.yml
@@ -142,13 +142,21 @@ jobs:
           DEVNET_ACCESSIBLE=false
           for attempt in 1 2 3; do
             echo "Devnet check attempt $attempt/3..."
-            HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 http://sesh-net.local:1280 2>/dev/null || echo '000')
-            if [ "$HTTP_CODE" != "000" ]; then
+            # curl writes its own "000" to stdout *and* exits non-zero when the connection fails, so
+            # its exit status is the signal, not the body. The previous form appended a fallback
+            # `|| echo '000'`, producing "000000" — which compares unequal to "000" and so reported an
+            # unreachable devnet as reachable, making this gate a no-op. The `|| CURL_RC=$?` form both
+            # captures the real status and keeps the step alive under the runner's default `bash -e`,
+            # which a bare assignment would not (a failing curl would abort before the check).
+            HTTP_CODE=""
+            CURL_RC=0
+            HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 http://sesh-net.local:1280 2>/dev/null) || CURL_RC=$?
+            if [ "$CURL_RC" -eq 0 ] && [ "$HTTP_CODE" != "000" ]; then
               echo "Devnet is reachable on attempt $attempt (HTTP $HTTP_CODE)"
               DEVNET_ACCESSIBLE=true
               break
             else
-              echo "Devnet attempt $attempt failed (could not connect)"
+              echo "Devnet attempt $attempt failed (curl rc=$CURL_RC, code=${HTTP_CODE:-none})"
               if [ $attempt -lt 3 ]; then
                 echo "Waiting ${attempt}s before retry..."
                 sleep $attempt

--- a/.github/workflows/android-regression.yml
+++ b/.github/workflows/android-regression.yml
@@ -13,6 +13,12 @@ on:
           - 'mainnet'
         default: 'devnet'
 
+      DEVNET_BOOTSTRAP:
+        description: 'devnet seed node as host:port (only used when NETWORK_TARGET=devnet)'
+        required: false
+        type: string
+        default: '192.168.1.114:1280'
+
       APK_URL:
         description: 'apk url to test (.tar.xz)'
         required: true
@@ -84,6 +90,10 @@ jobs:
       EMULATOR_FULL_PATH: '/opt/android/emulator/emulator'
       ANDROID_SDK_ROOT: '/opt/android'
       PLAYWRIGHT_RETRIES_COUNT: ${{ github.event.inputs.PLAYWRIGHT_RETRIES_COUNT }}
+      # Devnet seed node as host:port, editable per run. Only the reachability probe reads it today —
+      # see the TODO(android-devnet-env) note at that step. `vars.DEVNET_BOOTSTRAP_HOST` is a
+      # repo-level fallback shared with the iOS workflow for when the input is blanked.
+      DEVNET_BOOTSTRAP: ${{ github.event.inputs.DEVNET_BOOTSTRAP || vars.DEVNET_BOOTSTRAP_HOST || '192.168.1.114:1280' }}
       _TESTING: 1 # Always hide webdriver logs (@appium/support/ flag)
       PRINT_FAILED_TEST_LOGS: ${{ github.event.inputs.LOG_LEVEL != 'minimal' && '1' || '0' }} # Show stdout/stderr if test fails (@session-foundation/playwright-reporter/ flag)
       PRINT_ONGOING_TEST_LOGS: ${{ github.event.inputs.LOG_LEVEL == 'verbose' && '1' || '0' }} # Show everything as it happens (@session-foundation/playwright-reporter/ flag)
@@ -138,7 +148,18 @@ jobs:
 
           # Always probe devnet reachability so the log explains the decision,
           # regardless of which network target was requested.
-          echo "::group::Devnet reachability probe (http://sesh-net.local:1280)"
+          #
+          # The seed address comes from the DEVNET_BOOTSTRAP input, matching iOS, so moving the devnet
+          # does not need a code change. It replaces a hardcoded `sesh-net.local`, which stopped
+          # resolving — mDNS across the runner's network is not dependable, and it never resolved from
+          # inside the snode containers at all.
+          #
+          # TODO(android-devnet-env): this only feeds the *probe*. Android still reaches devnet via its
+          # AQA build variant rather than harness config, so a green probe here does not yet mean the
+          # app can reach that devnet — and run/constants/index.ts still hardcodes DEVNET_URL, which
+          # `isDevnetReachable()` uses to decide whether an AQA build is usable. Wire both to this
+          # value as part of the wider env-var work.
+          echo "::group::Devnet reachability probe (http://${DEVNET_BOOTSTRAP})"
           DEVNET_ACCESSIBLE=false
           for attempt in 1 2 3; do
             echo "Devnet check attempt $attempt/3..."
@@ -150,7 +171,7 @@ jobs:
             # which a bare assignment would not (a failing curl would abort before the check).
             HTTP_CODE=""
             CURL_RC=0
-            HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 http://sesh-net.local:1280 2>/dev/null) || CURL_RC=$?
+            HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "http://${DEVNET_BOOTSTRAP}" 2>/dev/null) || CURL_RC=$?
             if [ "$CURL_RC" -eq 0 ] && [ "$HTTP_CODE" != "000" ]; then
               echo "Devnet is reachable on attempt $attempt (HTTP $HTTP_CODE)"
               DEVNET_ACCESSIBLE=true

--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -147,22 +147,26 @@ jobs:
         run: |
           set -uo pipefail
           BOOT="http://${DEVNET_BOOTSTRAP_HOST}:${DEVNET_RPC_PORT:-1280}"
-          echo "Requested devnet -> probing seed node $BOOT"
+          echo "Requested devnet -> resolving from $BOOT"
+
+          # Retry around resolve_devnet.ts itself rather than a separate curl probe. A second
+          # reachability check is only another thing that can disagree with the real one, and the
+          # naive form of it is subtly wrong: `curl -w '%{http_code}' ... || echo 000` yields
+          # "000000" on a failed connection — curl prints its own 000 *and* exits non-zero — which is
+          # != "000" and therefore reads as success. The script's exit status is the single signal.
+          RESOLVED=""
           for attempt in 1 2 3; do
-            CODE=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "$BOOT" 2>/dev/null || echo '000')
-            if [ "$CODE" != "000" ]; then echo "Devnet reachable (HTTP $CODE)"; break; fi
+            if RESOLVED="$(npx --yes ts-node scripts/resolve_devnet.ts)"; then
+              break
+            fi
             echo "attempt $attempt/3 failed"
             if [ "$attempt" = 3 ]; then
-              echo "::error::devnet seed node $BOOT not reachable after 3 attempts"
+              echo "::error::could not resolve devnet from $BOOT after 3 attempts"
               exit 1
             fi
             sleep "$attempt"
           done
 
-          RESOLVED="$(npx --yes ts-node scripts/resolve_devnet.ts)" || {
-            echo "::error::could not resolve devnet connection details from $BOOT"
-            exit 1
-          }
           # An empty result would otherwise leave the harness to fall back to testnet silently.
           if [ -z "$RESOLVED" ]; then
             echo "::error::resolve_devnet.ts produced no values"

--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -96,18 +96,13 @@ jobs:
       PLAYWRIGHT_RETRIES_COUNT: ${{ github.event.inputs.PLAYWRIGHT_RETRIES_COUNT }}
       # iOS selects the network at launch (one build, no AQA/regular variants like Android):
       # NETWORK_TARGET drives capabilities_ios.ts + getNetworkTarget (and is used for the report).
-      # For devnet the app also needs the seed-node connection details below; they are only read
-      # when devnet is selected, so they are harmless on mainnet/testnet runs. Store them as
-      # repo-level Actions *variables* (the pubkey is public; the IP/ports are internal), e.g.
-      # Settings > Secrets and variables > Actions. The seed node exposes three ports the tests use:
-      # DEVNET_RPC_PORT (oxend RPC — the seeder), DEVNET_HTTP_PORT (storage HTTPS — the app) and
-      # DEVNET_OMQ_PORT (storage OMQ/QUIC — the app). See docs/local-devnet.md.
+      #
+      # For devnet the app also needs the seed node's pubkey/IP/ports. Those are NOT declared here:
+      # the "Resolve and probe devnet" step derives them from the devnet itself and exports them via
+      # $GITHUB_ENV, and a job-level `env:` entry would take precedence over $GITHUB_ENV and shadow
+      # the resolved values. Optional `vars.DEVNET_*` overrides are passed in at that step instead.
+      # See docs/local-devnet.md.
       NETWORK_TARGET: ${{ github.event.inputs.NETWORK_TARGET }}
-      DEVNET_PUBKEY: ${{ vars.DEVNET_PUBKEY }}
-      DEVNET_IP: ${{ vars.DEVNET_IP }}
-      DEVNET_RPC_PORT: ${{ vars.DEVNET_RPC_PORT }}
-      DEVNET_HTTP_PORT: ${{ vars.DEVNET_HTTP_PORT }}
-      DEVNET_OMQ_PORT: ${{ vars.DEVNET_OMQ_PORT }}
       _TESTING: 1 # Always hide webdriver logs (@appium/support/ flag)
       PRINT_FAILED_TEST_LOGS: ${{ github.event.inputs.LOG_LEVEL != 'minimal' && '1' || '0' }} # Show stdout/stderr if test fails (@session-foundation/playwright-reporter/ flag)
       PRINT_ONGOING_TEST_LOGS: ${{ github.event.inputs.LOG_LEVEL == 'verbose' && '1' || '0' }} # Show everything as it happens (@session-foundation/playwright-reporter/ flag)
@@ -128,28 +123,54 @@ jobs:
           PLATFORM: ${{ env.PLATFORM }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Fail fast (before the app download / sim setup) if devnet was requested but its
-      # connection details are missing or the seed node is unreachable. Mirrors the Android
-      # workflow's probe. On mainnet this step is skipped entirely.
-      - name: Probe devnet reachability
+      # Fail fast (before the app download / sim setup) if devnet was requested but the seed node is
+      # unreachable, then derive the connection details from the devnet rather than requiring them to
+      # be maintained by hand. Mirrors the Android workflow's probe, which uses the same bootstrap
+      # address. On mainnet/testnet this step is skipped entirely.
+      #
+      # Only the bootstrap address is configuration. Everything else comes from the seed's
+      # get_service_nodes RPC (see scripts/resolve_devnet.ts), which matters for two reasons: the
+      # pubkey is regenerated whenever the devnet is recreated, and the storage ports differ per node
+      # — so neither can be a hardcoded default. The IP is read from the registry, so it is by
+      # construction the address the client will be handed.
+      - name: Resolve and probe devnet
         if: ${{ github.event.inputs.NETWORK_TARGET == 'devnet' }}
         shell: bash
+        env:
+          DEVNET_BOOTSTRAP_HOST: ${{ vars.DEVNET_BOOTSTRAP_HOST || 'sesh-net.local' }}
+          # Optional pins. Each is left alone if set, so a variable still overrides autodetection.
+          DEVNET_PUBKEY: ${{ vars.DEVNET_PUBKEY }}
+          DEVNET_IP: ${{ vars.DEVNET_IP }}
+          DEVNET_RPC_PORT: ${{ vars.DEVNET_RPC_PORT }}
+          DEVNET_HTTP_PORT: ${{ vars.DEVNET_HTTP_PORT }}
+          DEVNET_OMQ_PORT: ${{ vars.DEVNET_OMQ_PORT }}
         run: |
-          if [ -z "$DEVNET_PUBKEY" ] || [ -z "$DEVNET_IP" ] || [ -z "$DEVNET_RPC_PORT" ] || [ -z "$DEVNET_HTTP_PORT" ] || [ -z "$DEVNET_OMQ_PORT" ]; then
-            echo "ERROR: NETWORK_TARGET=devnet but not all DEVNET_* Actions variables are set"
-            echo "  DEVNET_PUBKEY set? $([ -n "$DEVNET_PUBKEY" ] && echo yes || echo NO)"
-            echo "  DEVNET_IP='$DEVNET_IP' DEVNET_RPC_PORT='$DEVNET_RPC_PORT' DEVNET_HTTP_PORT='$DEVNET_HTTP_PORT' DEVNET_OMQ_PORT='$DEVNET_OMQ_PORT'"
+          set -uo pipefail
+          BOOT="http://${DEVNET_BOOTSTRAP_HOST}:${DEVNET_RPC_PORT:-1280}"
+          echo "Requested devnet -> probing seed node $BOOT"
+          for attempt in 1 2 3; do
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "$BOOT" 2>/dev/null || echo '000')
+            if [ "$CODE" != "000" ]; then echo "Devnet reachable (HTTP $CODE)"; break; fi
+            echo "attempt $attempt/3 failed"
+            if [ "$attempt" = 3 ]; then
+              echo "::error::devnet seed node $BOOT not reachable after 3 attempts"
+              exit 1
+            fi
+            sleep "$attempt"
+          done
+
+          RESOLVED="$(npx --yes ts-node scripts/resolve_devnet.ts)" || {
+            echo "::error::could not resolve devnet connection details from $BOOT"
+            exit 1
+          }
+          # An empty result would otherwise leave the harness to fall back to testnet silently.
+          if [ -z "$RESOLVED" ]; then
+            echo "::error::resolve_devnet.ts produced no values"
             exit 1
           fi
-          # Probe the seeder's endpoint (oxend RPC); the app's storage ports are validated in-harness.
-          SEED="http://${DEVNET_IP}:${DEVNET_RPC_PORT}"
-          echo "Requested devnet -> probing seed node $SEED"
-          for attempt in 1 2 3; do
-            CODE=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "$SEED" 2>/dev/null || echo '000')
-            if [ "$CODE" != "000" ]; then echo "Devnet reachable (HTTP $CODE)"; exit 0; fi
-            echo "attempt $attempt/3 failed"; [ "$attempt" -lt 3 ] && sleep "$attempt"
-          done
-          echo "ERROR: devnet seed node $SEED not reachable after 3 attempts"; exit 1
+          echo "$RESOLVED" >> "$GITHUB_ENV"
+          echo "Resolved devnet details (all non-secret — the pubkey is a service-node public key):"
+          echo "$RESOLVED"
 
       - name: Download ipa and extract it
         run: |

--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -14,6 +14,12 @@ on:
           - 'mainnet'
         default: 'mainnet'
 
+      DEVNET_BOOTSTRAP:
+        description: 'devnet seed node as host:port (only used when NETWORK_TARGET=devnet)'
+        required: false
+        type: string
+        default: '192.168.1.114:1280'
+
       APK_URL:
         description: 'ipa url to test (.tar.xz)'
         required: true
@@ -137,7 +143,10 @@ jobs:
         if: ${{ github.event.inputs.NETWORK_TARGET == 'devnet' }}
         shell: bash
         env:
-          DEVNET_BOOTSTRAP_HOST: ${{ vars.DEVNET_BOOTSTRAP_HOST || 'sesh-net.local' }}
+          # Editable per run via the DEVNET_BOOTSTRAP input, so moving the devnet does not need a code
+          # change. Accepts host, host:port or a full URL. `vars.DEVNET_BOOTSTRAP_HOST` remains as a
+          # repo-level fallback for when the input is blanked.
+          DEVNET_BOOTSTRAP_HOST: ${{ github.event.inputs.DEVNET_BOOTSTRAP || vars.DEVNET_BOOTSTRAP_HOST || '192.168.1.114:1280' }}
           # Optional pins. Each is left alone if set, so a variable still overrides autodetection.
           DEVNET_PUBKEY: ${{ vars.DEVNET_PUBKEY }}
           DEVNET_IP: ${{ vars.DEVNET_IP }}

--- a/docs/local-devnet.md
+++ b/docs/local-devnet.md
@@ -259,9 +259,19 @@ input (`devnet`/`testnet`/`mainnet`); the macOS runner reaches a **Linux-hosted*
 network (Tailscale/LAN).
 
 **There is normally nothing to configure.** The "Resolve and probe devnet" step derives the
-connection details from the devnet itself, so the only input is the bootstrap address — which
-defaults to `sesh-net.local:1280`, the same address the Android workflow probes. Override it with a
-`DEVNET_BOOTSTRAP_HOST` repo variable if that name doesn't resolve on the runner.
+connection details from the devnet itself, so the only input is the bootstrap address — exposed as the
+**`DEVNET_BOOTSTRAP`** workflow input (default `192.168.1.114:1280`) so it can be changed per run
+without a code change. It accepts a bare host, `host:port`, or a full URL. A
+`vars.DEVNET_BOOTSTRAP_HOST` repo variable acts as a fallback if the input is blanked.
+
+> Not `sesh-net.local` any more: mDNS stopped resolving on the runner, and it never worked from inside
+> the snode containers regardless (no mDNS resolver there).
+>
+> The Android workflow takes the **same `DEVNET_BOOTSTRAP` input with the same default**, but it only
+> feeds the reachability probe there: Android still reaches devnet via its AQA build variant rather
+> than harness config, and `run/constants/index.ts` hardcodes `DEVNET_URL` (used by
+> `isDevnetReachable()` to decide whether an AQA build is usable). So a green probe on Android does not
+> yet mean the app can reach that devnet — see `TODO(android-devnet-env)`.
 
 Each value below can still be pinned with a repo-level Actions variable of the same name (Settings →
 Secrets and variables → Actions → _Variables_, not Secrets — the workflow reads `vars.*`). A pinned

--- a/docs/local-devnet.md
+++ b/docs/local-devnet.md
@@ -124,6 +124,33 @@ the app's launch-arg env) and the seeder (`getNetworkTarget` targets
 `http://$DEVNET_IP:$DEVNET_RPC_PORT`). If any `DEVNET_*` value is missing/invalid, the run fails
 fast with a message naming what's wrong.
 
+## 4a. Shortcut: resolve everything at once
+
+Sections 4b and 4c explain where each value comes from. To skip the manual capture:
+
+```bash
+npx ts-node scripts/resolve_devnet.ts --host <DEVNET_IP> >> .env
+```
+
+That emits the `DEVNET_*` values plus `FILE_SERVER_URL`, `FILE_SERVER_PUBKEY`, `COMMUNITY_LINK`,
+`COMMUNITY_NAME` and `COMMUNITY_ROOM`.
+
+**The devnet must resolve or the command fails.** The file server and SOGS are then attempted as
+best-effort optimisations — each is probed independently, whichever is reachable is emitted, and
+whichever is not is warned about and omitted so the harness stays on the production file server /
+remote community. A devnet-only stack (`cd sesh-net && docker compose up`) therefore works fine; you
+get two warnings and the `DEVNET_*` values. Pass `--no-services` to skip probing them altogether.
+
+The host for all three services is the devnet IP read from the
+service-node registry, which is what the onion path needs — the app reaches the file server and SOGS
+_through the snodes_, so the URL must resolve inside the snode containers. An mDNS `.local` name will
+**not** work for these two (containers have no mDNS resolver), which is why the resolved IP is used
+even when the bootstrap address was a hostname.
+
+The room token and name are read from the SOGS `/rooms` API. The two pubkeys are baked deterministic
+keys and are not exposed over HTTP, so they are built-in constants — set the matching env var to
+override either. Anything already set in the environment is left alone.
+
 ## 4b. (Optional) local file server
 
 The file server comes up **with the devnet** — the `docker compose up --build` from step 2 also
@@ -228,10 +255,42 @@ After `docker compose up`, confirm before trusting a run:
 ## CI
 
 Nothing in CI changes when you set this up locally. `ios-regression.yml` exposes a `NETWORK_TARGET`
-input (`devnet`/`testnet`/`mainnet`) and reads the devnet connection details from repo-level Actions
-variables (`DEVNET_PUBKEY`, `DEVNET_IP`, `DEVNET_HTTP_PORT`, `DEVNET_OMQ_PORT`). The macOS runner
-reaches a **Linux-hosted** devnet over the network (Tailscale/LAN) — the only per-environment
-difference is the IP value, which is already env-driven.
+input (`devnet`/`testnet`/`mainnet`); the macOS runner reaches a **Linux-hosted** devnet over the
+network (Tailscale/LAN).
+
+**There is normally nothing to configure.** The "Resolve and probe devnet" step derives the
+connection details from the devnet itself, so the only input is the bootstrap address — which
+defaults to `sesh-net.local:1280`, the same address the Android workflow probes. Override it with a
+`DEVNET_BOOTSTRAP_HOST` repo variable if that name doesn't resolve on the runner.
+
+Each value below can still be pinned with a repo-level Actions variable of the same name (Settings →
+Secrets and variables → Actions → _Variables_, not Secrets — the workflow reads `vars.*`). A pinned
+value is used as-is and skips autodetection for that field:
+
+| Variable           | Notes                                                                       |
+| ------------------ | --------------------------------------------------------------------------- |
+| `DEVNET_PUBKEY`    | 64-char hex. **Drifts** whenever the devnet is recreated — see below.       |
+| `DEVNET_IP`        | Must be IPv4 — a hostname is rejected by the harness _and_ by the app.      |
+| `DEVNET_RPC_PORT`  | Seed oxend RPC, used by the seeder. Conventionally `1280`.                  |
+| `DEVNET_HTTP_PORT` | Seed storage HTTPS, used by the app. Per-node, **not** a fixed constant.    |
+| `DEVNET_OMQ_PORT`  | Seed storage OMQ/QUIC, used by the app. Per-node, **not** a fixed constant. |
+
+> The storage ports differ per node and per devnet — a 12-node devnet has twelve different
+> `storage_port`/`storage_lmq_port` pairs, so the example values above are illustrative only. Read
+> them for the node you actually pick rather than assuming `1300`/`1305`.
+
+Rather than maintaining these by hand, `scripts/resolve_devnet.ts` derives everything except the
+bootstrap address from the seed's `get_service_nodes` RPC, so the only thing CI needs to know is
+where to bootstrap:
+
+```bash
+npx ts-node scripts/resolve_devnet.ts --host sesh-net.local --rpc-port 1280
+```
+
+It prints `KEY=value` lines suitable for `$GITHUB_ENV` or a local `.env`, and it takes `public_ip`
+from the registry — the same address the client will be handed — so it cannot drift out of step with
+what the snodes advertise. Values already set in the environment are left alone, so a variable still
+overrides autodetection.
 
 ## Notes & gotchas
 

--- a/run/constants/index.ts
+++ b/run/constants/index.ts
@@ -19,8 +19,6 @@ export { longText } from '../shared/constants';
 
 export { testLink } from '../shared/constants';
 
-export const DEVNET_URL = 'http://sesh-net.local:1280';
-
 export const PRO_BACKEND_URL = 'https://pro.session.codes';
 
 export const ONS_MAPPINGS = {

--- a/run/shared/devnet_bootstrap.ts
+++ b/run/shared/devnet_bootstrap.ts
@@ -1,0 +1,64 @@
+/**
+ * The devnet seed node's address — the one piece of devnet config that is not discoverable, since it
+ * is what you bootstrap *from*. Everything else is read off the seed's `get_service_nodes` RPC (see
+ * `scripts/resolve_devnet.ts`).
+ *
+ * Deliberately dependency-free, including no `dotenv`. It is imported both by the harness (where
+ * `playwright.config.ts` has already loaded `.env`) and by `scripts/resolve_devnet.ts`, which must
+ * *not* see `.env`: existing `DEVNET_*` values there are treated as pins to preserve, so loading them
+ * would make the script echo a stale config back instead of resolving a fresh one.
+ */
+
+/**
+ * Was `sesh-net.local`, which stopped resolving. mDNS across the runner's network is not dependable,
+ * and it never resolved from inside the snode containers at all — so it cannot be used for the file
+ * server or SOGS either, which the app reaches through the snodes.
+ *
+ * Overridable per run by the `DEVNET_BOOTSTRAP` workflow input on both regression workflows, which
+ * arrives here as `DEVNET_BOOTSTRAP_HOST`.
+ */
+export const DEFAULT_DEVNET_BOOTSTRAP = '192.168.1.114:1280';
+
+/** Fallback RPC port when the bootstrap address carries no `:port`. */
+export const DEFAULT_DEVNET_RPC_PORT = '1280';
+
+/**
+ * Splits a bootstrap address into host and optional port.
+ *
+ * The address is surfaced as a single editable field, so it has to tolerate what people actually
+ * paste: a bare host, `host:port`, or a full URL. Getting this wrong fails silently rather than
+ * loudly — a scheme left on the front turns into `http://http://host:1280/json_rpc`.
+ */
+export function splitBootstrap(value: string): { host: string; port?: string } {
+  const bare = value
+    .trim()
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, '') // scheme
+    .replace(/\/.*$/, ''); // path
+  const match = /^(.*):(\d{1,5})$/.exec(bare);
+  return match ? { host: match[1], port: match[2] } : { host: bare };
+}
+
+/** Treats empty/whitespace as absent — an unset Actions `vars.X` arrives as the empty string. */
+const envOr = (name: string, fallback: string): string => {
+  const value = (process.env[name] ?? '').trim();
+  return value === '' ? fallback : value;
+};
+
+/**
+ * The devnet seed node's base URL, e.g. `http://192.168.1.114:1280`.
+ *
+ * Resolved on every call rather than captured in a module-level constant: `run/constants/index.ts`
+ * does not load `.env`, so a value frozen at import time would depend on which module happened to
+ * call `dotenv.config()` first.
+ *
+ * An explicit `DEVNET_RPC_PORT` beats a port embedded in the bootstrap address.
+ *
+ * Returns the `http://${string}` template type rather than plain `string` so it still satisfies the
+ * seeder's network parameter (`'mainnet' | 'testnet' | \`http${string}\``), which the previous
+ * hardcoded constant satisfied by virtue of being a literal.
+ */
+export function getDevnetBootstrapUrl(): `http://${string}` {
+  const { host, port } = splitBootstrap(envOr('DEVNET_BOOTSTRAP_HOST', DEFAULT_DEVNET_BOOTSTRAP));
+  const explicitPort = (process.env.DEVNET_RPC_PORT ?? '').trim();
+  return `http://${host}:${explicitPort || port || DEFAULT_DEVNET_RPC_PORT}`;
+}

--- a/run/test/utils/devnet.ts
+++ b/run/test/utils/devnet.ts
@@ -2,7 +2,7 @@ import { buildStateForTest } from '@session-foundation/qa-seeder';
 
 import type { SupportedPlatformsType } from './open_app';
 
-import { DEVNET_URL } from '../../constants';
+import { getDevnetBootstrapUrl } from '../../shared/devnet_bootstrap';
 import { sleepFor } from '../../shared/promise_utils';
 import { AppName } from '../../types/testing';
 import { getAndroidApk } from './binaries';
@@ -12,7 +12,7 @@ import { getIosDevnetSeedUrl, getIosServiceNetwork } from './capabilities_ios';
 type NetworkType = Parameters<typeof buildStateForTest>[2];
 
 // Using native fetch to check devnet accessibility
-async function isDevnetReachable(url: string = DEVNET_URL): Promise<boolean> {
+async function isDevnetReachable(url: string = getDevnetBootstrapUrl()): Promise<boolean> {
   const isCI = process.env.CI === '1';
   const maxAttempts = isCI ? 3 : 1;
   const timeout = isCI ? 10_000 : 2_000;
@@ -101,17 +101,21 @@ export async function getNetworkTarget(platform: SupportedPlatformsType): Promis
     return 'mainnet';
   }
 
-  const canAccessDevnet = await isDevnetReachable();
+  const devnetUrl = getDevnetBootstrapUrl();
+  const canAccessDevnet = await isDevnetReachable(devnetUrl);
   // If you pass an AQA build in the .env but can't access devnet, tests will fail
   if (isAQA && !canAccessDevnet) {
-    throw new Error('Cannot use AQA build without internal network access');
+    throw new Error(
+      `Cannot use AQA build without internal network access (devnet ${devnetUrl} unreachable). ` +
+        `Set DEVNET_BOOTSTRAP_HOST (or the DEVNET_BOOTSTRAP workflow input) if the devnet moved.`
+    );
   }
   // If the devnet is available, mainnet is still an option but you *could* switch to an AQA build
   if (!isAQA && canAccessDevnet) {
     console.log('The internal devnet is available, but using regular build');
   }
 
-  const resolvedTarget = isAQA && canAccessDevnet ? DEVNET_URL : 'mainnet';
+  const resolvedTarget = isAQA && canAccessDevnet ? devnetUrl : 'mainnet';
   process.env.DETECTED_NETWORK_TARGET = resolvedTarget;
   console.log(`Network target: ${resolvedTarget}`);
 

--- a/run/test/utils/devnet.ts
+++ b/run/test/utils/devnet.ts
@@ -11,7 +11,16 @@ import { getIosDevnetSeedUrl, getIosServiceNetwork } from './capabilities_ios';
 // NOTE this currently only applies to Android as iOS doesn't supply AQA builds yet
 type NetworkType = Parameters<typeof buildStateForTest>[2];
 
-// Using native fetch to check devnet accessibility
+/**
+ * Checks the devnet by asking its oxend RPC for the service-node list — the same call the seeder
+ * makes, so a pass means the address is genuinely usable rather than merely occupied.
+ *
+ * This deliberately does not `GET` the root. oxend answers `404` there (only `POST /json_rpc` is a
+ * route), so a status-only check has to accept 404 as healthy — at which point *any* HTTP listener
+ * passes, and pointing this at the SOGS port or a router page would report the devnet up and push the
+ * real failure into the middle of a test run. It also logged "is accessible (HTTP 404)", which reads
+ * like a fault when it isn't.
+ */
 async function isDevnetReachable(url: string = getDevnetBootstrapUrl()): Promise<boolean> {
   const isCI = process.env.CI === '1';
   const maxAttempts = isCI ? 3 : 1;
@@ -27,10 +36,30 @@ async function isDevnetReachable(url: string = getDevnetBootstrapUrl()): Promise
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-      const response = await fetch(url, { signal: controller.signal });
+      const response = await fetch(`${url}/json_rpc`, {
+        body: JSON.stringify({ id: '0', jsonrpc: '2.0', method: 'get_service_nodes' }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+        signal: controller.signal,
+      });
       clearTimeout(timeoutId);
 
-      console.log(`Devnet ${url} is accessible (HTTP ${response.status})`);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} from ${url}/json_rpc`);
+      }
+      const body = (await response.json()) as {
+        result?: { service_node_states?: { active?: boolean }[] };
+      };
+      const nodes = body.result?.service_node_states;
+      if (!Array.isArray(nodes)) {
+        // Something is listening and speaking HTTP, but it is not an oxend RPC.
+        throw new Error(`${url} responded but returned no service_node_states — not a devnet?`);
+      }
+
+      // Node counts rather than a status code: an oxend reporting zero active nodes is reachable but
+      // not yet usable, and that is worth seeing in the log rather than discovering mid-run.
+      const active = nodes.filter(n => n.active).length;
+      console.log(`Devnet ${url} is accessible (${nodes.length} service nodes, ${active} active)`);
       return true;
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : 'Unknown error';

--- a/scripts/resolve_devnet.ts
+++ b/scripts/resolve_devnet.ts
@@ -34,8 +34,18 @@
  * so an explicit variable still wins over autodetection.
  */
 
-const DEFAULT_HOST = 'sesh-net.local';
-const DEFAULT_RPC_PORT = '1280';
+// Shared with the harness so the default and the parsing cannot drift apart — see
+// run/shared/devnet_bootstrap.ts. That module is deliberately dependency-free, so importing it here
+// does not pull dotenv in: this script must NOT see .env, since existing DEVNET_* values are treated
+// as pins to preserve and would make it echo a stale config back instead of resolving a fresh one.
+import {
+  DEFAULT_DEVNET_BOOTSTRAP,
+  DEFAULT_DEVNET_RPC_PORT,
+  splitBootstrap,
+} from '../run/shared/devnet_bootstrap';
+
+const DEFAULT_HOST = DEFAULT_DEVNET_BOOTSTRAP;
+const DEFAULT_RPC_PORT = DEFAULT_DEVNET_RPC_PORT;
 
 /**
  * Defaults for the optional local file server and SOGS from the same Sesh-Net-Docker stack
@@ -86,8 +96,11 @@ const envOr = (name: string, fallback: string): string => {
 };
 
 function parseArgs(argv: string[]): { host: string; rpcPort: string; skipServices: boolean } {
-  let host = envOr('DEVNET_BOOTSTRAP_HOST', DEFAULT_HOST);
+  const bootstrap = envOr('DEVNET_BOOTSTRAP_HOST', DEFAULT_HOST);
+  let host = bootstrap;
   let rpcPort = envOr('DEVNET_RPC_PORT', DEFAULT_RPC_PORT);
+  // A port pinned explicitly (flag or env var) beats one embedded in the bootstrap address.
+  let rpcPortExplicit = (process.env.DEVNET_RPC_PORT ?? '').trim() !== '';
   let skipServices = false;
 
   for (let i = 0; i < argv.length; i++) {
@@ -100,13 +113,24 @@ function parseArgs(argv: string[]): { host: string; rpcPort: string; skipService
       if (inlineValue === undefined) i++;
     } else if (flag === '--rpc-port') {
       rpcPort = value ?? rpcPort;
+      rpcPortExplicit = true;
       if (inlineValue === undefined) i++;
     } else {
       console.error(`Unknown argument: "${argv[i]}"`);
       process.exit(1);
     }
   }
-  return { host, rpcPort, skipServices };
+
+  const split = splitBootstrap(host);
+  if (split.host === '') {
+    console.error(`Empty devnet bootstrap address (got "${host}").`);
+    process.exit(1);
+  }
+  return {
+    host: split.host,
+    rpcPort: rpcPortExplicit ? rpcPort : (split.port ?? rpcPort),
+    skipServices,
+  };
 }
 
 const reason = (error: unknown): string => (error instanceof Error ? error.message : String(error));

--- a/scripts/resolve_devnet.ts
+++ b/scripts/resolve_devnet.ts
@@ -1,0 +1,276 @@
+/**
+ * Derives the `DEVNET_*` connection details from a running devnet instead of maintaining them by
+ * hand as Actions variables / `.env` entries.
+ *
+ * Everything except the bootstrap address comes from one `get_service_nodes` call on the seed's
+ * oxend RPC — the same call the seeder already makes:
+ *
+ *   DEVNET_PUBKEY    <- pubkey_ed25519
+ *   DEVNET_IP        <- public_ip
+ *   DEVNET_HTTP_PORT <- storage_port
+ *   DEVNET_OMQ_PORT  <- storage_lmq_port
+ *
+ * Taking `public_ip` from the registry is the point, not a convenience: each snode advertises its
+ * `LISTEN_IP` there and the client connects to whatever it finds, so reading the advertised value is
+ * the only way these cannot drift out of step with what the client will actually be handed. It also
+ * means the bootstrap address may be an mDNS name (`sesh-net.local`) even though the app itself
+ * requires IPv4 — we resolve to the advertised IP before anything validates it.
+ *
+ * The storage ports are per-node (a 12-node devnet has twelve distinct pairs), so they cannot be
+ * defaulted to constants; they have to be read for whichever node is chosen.
+ *
+ * Usage:
+ *   npx ts-node scripts/resolve_devnet.ts                                  # sesh-net.local:1280
+ *   npx ts-node scripts/resolve_devnet.ts --host 192.168.139.2             # explicit host
+ *   npx ts-node scripts/resolve_devnet.ts --host x --rpc-port 1280         # explicit port
+ *   npx ts-node scripts/resolve_devnet.ts --no-services                    # devnet only
+ *
+ * The devnet itself must resolve or this exits non-zero. The optional local file server and SOGS are
+ * then attempted as best-effort optimisations: whichever is reachable is emitted, whichever is not is
+ * warned about and omitted, leaving the harness on the production file server / remote community.
+ *
+ * Prints `KEY=value` lines on stdout (append to `$GITHUB_ENV`, or paste into `.env`); diagnostics go
+ * to stderr so stdout stays machine-readable. Anything already set in the environment is preserved,
+ * so an explicit variable still wins over autodetection.
+ */
+
+const DEFAULT_HOST = 'sesh-net.local';
+const DEFAULT_RPC_PORT = '1280';
+
+/**
+ * Defaults for the optional local file server and SOGS from the same Sesh-Net-Docker stack
+ * (docs/local-devnet.md §4b/§4c).
+ *
+ * Only the *host* varies, and it is the devnet IP we already resolve — the compose runs
+ * `network_mode: host`, so all three services share one address. Verified from inside a snode
+ * container, which is the side that matters: the app reaches both over an onion request through the
+ * snodes, so the URL has to resolve *there*, not on the machine running the tests. (This is also why
+ * an mDNS `.local` name does not work for these two — containers have no mDNS resolver.)
+ *
+ * The two pubkeys are baked deterministic keys, so they are constants rather than something to
+ * discover; neither service exposes its key over HTTP. Both were read from the running containers and
+ * match `.env.sample`. Re-derive with:
+ *   docker compose logs sogs       | grep -i 'server pubkey'
+ *   docker compose logs fileserver | grep -i 'X25519 pubkey'
+ * If the stack ever rotates them, override with the matching env var rather than editing these.
+ */
+const SERVICE_DEFAULTS = {
+  /** X25519 — LibSession-Util consumes it directly as x25519; the ed25519 key will NOT work. */
+  fileServerPubkey: '51bda59019c34e34c1dfcdf279b1c4e4da5cfc8c2cbb1e2942d443890ac8c43e',
+  fileServerPort: '8000',
+  /** X25519 server pubkey; this is what pins the community, independent of host. */
+  sogsPubkey: 'aa7c2b3bcd6433e52d6616356fcdba68668e8b506d84a3c7a1a196d63235a613',
+  sogsPort: '8080',
+} as const;
+
+type SogsRoom = {
+  name?: string;
+  token?: string;
+};
+
+type ServiceNodeState = {
+  active?: boolean;
+  pubkey_ed25519?: string;
+  public_ip?: string;
+  storage_lmq_port?: number;
+  storage_port?: number;
+};
+
+/**
+ * Treats an empty/whitespace value as absent. Actions exposes an unset `vars.X` as the empty string
+ * rather than leaving it undefined, so `??` alone would accept `''` and defeat every default here.
+ */
+const envOr = (name: string, fallback: string): string => {
+  const value = (process.env[name] ?? '').trim();
+  return value === '' ? fallback : value;
+};
+
+function parseArgs(argv: string[]): { host: string; rpcPort: string; skipServices: boolean } {
+  let host = envOr('DEVNET_BOOTSTRAP_HOST', DEFAULT_HOST);
+  let rpcPort = envOr('DEVNET_RPC_PORT', DEFAULT_RPC_PORT);
+  let skipServices = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const [flag, inlineValue] = argv[i].split('=');
+    const value = inlineValue ?? argv[i + 1];
+    if (flag === '--no-services') {
+      skipServices = true;
+    } else if (flag === '--host') {
+      host = value ?? host;
+      if (inlineValue === undefined) i++;
+    } else if (flag === '--rpc-port') {
+      rpcPort = value ?? rpcPort;
+      if (inlineValue === undefined) i++;
+    } else {
+      console.error(`Unknown argument: "${argv[i]}"`);
+      process.exit(1);
+    }
+  }
+  return { host, rpcPort, skipServices };
+}
+
+const reason = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+
+/**
+ * Best-effort file server + SOGS values, keyed off the already-resolved devnet IP.
+ *
+ * Both are **optimisations, not requirements** (docs/local-devnet.md §4b/§4c): omitting their values
+ * makes the harness fall back to the production file server and the remote community, which is a
+ * working configuration — just a slower one. So a service that is absent is warned about and skipped
+ * rather than failing the run, and the two are probed independently so one being down does not hide
+ * the state of the other.
+ *
+ * Never exits: the caller has already resolved the devnet, which is the part that must succeed.
+ */
+async function resolveServices(ip: string): Promise<Record<string, string>> {
+  const resolved: Record<string, string> = {};
+  const sogsPort = envOr('SOGS_PORT', SERVICE_DEFAULTS.sogsPort);
+  const fileServerPort = envOr('FILE_SERVER_PORT', SERVICE_DEFAULTS.fileServerPort);
+
+  const sogsBase = `http://${ip}:${sogsPort}`;
+  try {
+    const response = await fetch(`${sogsBase}/rooms`, { signal: AbortSignal.timeout(10_000) });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const rooms = (await response.json()) as SogsRoom[];
+    if (!Array.isArray(rooms) || rooms.length === 0) {
+      throw new Error('no rooms returned');
+    }
+
+    // The stack creates a primary room plus numbered siblings (…-2 … -6), and the primary is the
+    // shortest token. Sorting rather than taking rooms[0] keeps the choice stable across calls, so a
+    // room-specific problem cannot present as an intermittent one.
+    const primary = rooms
+      .filter(
+        (r): r is Required<SogsRoom> => typeof r.token === 'string' && typeof r.name === 'string'
+      )
+      .sort((a, b) => a.token.length - b.token.length || a.token.localeCompare(b.token))[0];
+    if (!primary) {
+      throw new Error(`${rooms.length} room(s), none with a usable token/name`);
+    }
+
+    resolved.COMMUNITY_LINK = `${sogsBase}/${primary.token}?public_key=${envOr('SOGS_PUBKEY', SERVICE_DEFAULTS.sogsPubkey)}`;
+    resolved.COMMUNITY_NAME = primary.name;
+    resolved.COMMUNITY_ROOM = primary.token;
+    console.error(`  SOGS         : ${sogsBase} — room "${primary.token}" of ${rooms.length}`);
+  } catch (error) {
+    console.error(
+      `  SOGS         : unavailable at ${sogsBase} (${reason(error)})\n` +
+        `                 -> community tests will use the remote community instead`
+    );
+  }
+
+  // No health route — the root 404s when healthy — so "reachable" means the connection succeeded at
+  // all, whatever the status.
+  const fileServerUrl = `http://${ip}:${fileServerPort}`;
+  try {
+    await fetch(`${fileServerUrl}/`, { signal: AbortSignal.timeout(10_000) });
+    resolved.FILE_SERVER_PUBKEY = envOr('FILE_SERVER_PUBKEY', SERVICE_DEFAULTS.fileServerPubkey);
+    resolved.FILE_SERVER_URL = fileServerUrl;
+    console.error(`  file server  : ${fileServerUrl}`);
+  } catch (error) {
+    console.error(
+      `  file server  : unavailable at ${fileServerUrl} (${reason(error)})\n` +
+        `                 -> media tests will use the production file server instead`
+    );
+  }
+
+  return resolved;
+}
+
+const isIpv4 = (ip: string): boolean => {
+  const octets = ip.split('.');
+  return octets.length === 4 && octets.every(o => /^\d{1,3}$/.test(o) && Number(o) <= 255);
+};
+
+const isPort = (p: unknown): boolean =>
+  typeof p === 'number' && Number.isInteger(p) && p > 0 && p <= 65535;
+
+async function main(): Promise<void> {
+  const { host, rpcPort, skipServices } = parseArgs(process.argv.slice(2));
+  const url = `http://${host}:${rpcPort}/json_rpc`;
+  console.error(`Resolving devnet details from ${url}`);
+
+  let states: ServiceNodeState[];
+  try {
+    const response = await fetch(url, {
+      body: JSON.stringify({ id: '0', jsonrpc: '2.0', method: 'get_service_nodes' }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const body = (await response.json()) as { result?: { service_node_states?: unknown } };
+    const raw = body.result?.service_node_states;
+    if (!Array.isArray(raw)) {
+      throw new Error('response had no result.service_node_states array');
+    }
+    states = raw as ServiceNodeState[];
+  } catch (error) {
+    console.error(
+      `Could not reach the devnet seed at ${url}: ${error instanceof Error ? error.message : String(error)}`
+    );
+    process.exit(1);
+  }
+
+  // Only fully-usable nodes are candidates, and the choice is made deterministic by sorting on the
+  // pubkey: an arbitrary "first active" would silently pick a different seed between runs, which
+  // turns any seed-specific problem into an intermittent one.
+  const candidates = states
+    .filter(
+      s =>
+        s.active === true &&
+        typeof s.pubkey_ed25519 === 'string' &&
+        /^[0-9a-fA-F]{64}$/.test(s.pubkey_ed25519) &&
+        typeof s.public_ip === 'string' &&
+        isIpv4(s.public_ip) &&
+        isPort(s.storage_port) &&
+        isPort(s.storage_lmq_port)
+    )
+    .sort((a, b) => (a.pubkey_ed25519 ?? '').localeCompare(b.pubkey_ed25519 ?? ''));
+
+  if (candidates.length === 0) {
+    console.error(
+      `No usable service node found (${states.length} returned, ` +
+        `${states.filter(s => s.active).length} active). A devnet that is still coming up reports ` +
+        `nodes without storage ports — retry once it has settled.`
+    );
+    process.exit(1);
+  }
+
+  const node = candidates[0];
+  console.error(`Using seed ${node.pubkey_ed25519?.slice(0, 16)}… of ${candidates.length} usable`);
+
+  const ip = String(node.public_ip);
+  const resolved: Record<string, string> = {
+    DEVNET_HTTP_PORT: String(node.storage_port),
+    DEVNET_IP: ip,
+    DEVNET_OMQ_PORT: String(node.storage_lmq_port),
+    DEVNET_PUBKEY: String(node.pubkey_ed25519),
+    DEVNET_RPC_PORT: rpcPort,
+  };
+
+  if (!skipServices) {
+    // Keyed off the advertised IP, so the file server and SOGS are addressed the same way the snodes
+    // address them — which is what the onion path requires. Best-effort: whatever is missing is
+    // warned about and omitted, leaving the harness on its remote/production defaults.
+    console.error('Optional local services:');
+    Object.assign(resolved, await resolveServices(ip));
+  }
+
+  for (const [key, value] of Object.entries(resolved)) {
+    const existing = (process.env[key] ?? '').trim();
+    // An explicitly-set value wins, so a repo variable can still pin something deliberately.
+    if (existing && key !== 'DEVNET_RPC_PORT') {
+      console.error(`  ${key}: keeping existing value`);
+      console.log(`${key}=${existing}`);
+      continue;
+    }
+    console.log(`${key}=${value}`);
+  }
+}
+
+void main();


### PR DESCRIPTION
FILE_SERVER_URL and COMMUNITY_LINK embed the devnet host, which varies per environment, so both had to be maintained by hand next to the DEVNET_* values.

resolve_devnet.ts now derives them from the already-resolved service-node IP, with the room token and name read from the SOGS /rooms API. Both services are probed independently and treated as optimisations: whichever is reachable is emitted, whichever is not is warned about and omitted, leaving the harness on the production file server and remote community. The devnet itself must still resolve.

The two server pubkeys are baked deterministic keys that neither service exposes over HTTP, so they are built-in constants with an env override. The resolved IP is used rather than the bootstrap hostname because the app reaches both services over onion requests through the snodes, and containers cannot resolve mDNS .local names.