### PR TITLE
test(community): give each community test its own SOGS rooms 

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -65,18 +65,12 @@ UPDATE_BASELINES='false' # true auto-saves missing baseline screenshots
 # COMMUNITY_ROOM=local-devnet-community
 
 # With COMMUNITY_LINK set, each community test creates rooms of its own and deletes them afterwards,
-# so concurrent runs (CI and a laptop, or two CI jobs) can't interfere. Creating a room has no HTTP
-# endpoint in PySOGS, so it goes through Sesh-Net-Docker's room.sh, which shells into the container.
+# so concurrent runs (CI and a laptop, or two CI jobs) can't interfere. This needs nothing beyond the
+# three vars above and SOGS_ADMIN_SEED: rooms are created and deleted over SOGS' own HTTP API, signed
+# as that account, which has to be a global admin on the server (locally it is by default — see
+# SOGS_ADMIN_SESSION_IDS in Sesh-Net-Docker/sogs/docker-compose.yml).
 #
-# Defaults to a Sesh-Net-Docker checkout sitting alongside this repo; set this when yours is
-# elsewhere. Checked once at startup by listing rooms — if that doesn't work (no CLI, no docker,
-# container down) the run falls back to the shared rooms with a loud warning rather than failing,
-# since that still tests everything, just without isolating concurrent runs.
-# SOGS_ROOM_CLI=/path/to/Sesh-Net-Docker/sogs/room.sh
-#
-# Alternative to the CLI, for machines that can reach the SOGS container over the network but can't
-# `docker exec` into it (a CI runner whose devnet is on another host). Sesh-Net-Docker's sogs
-# container exposes the same create/delete/gc operations on :8081 when its SOGS_ROOM_API_TOKEN is
-# set; give the same token here. Takes precedence over SOGS_ROOM_CLI when set.
-# SOGS_ROOM_API=http://10.0.0.1:8081
-# SOGS_ROOM_API_TOKEN=<same value as the container's SOGS_ROOM_API_TOKEN>
+# Checked once at startup by listing rooms. If that doesn't work — SOGS unreachable, the account not a
+# global admin, a server too old to have the endpoints — the run falls back to the shared rooms with a
+# loud warning rather than failing, since that still tests everything, just without isolating
+# concurrent runs. See docs/local-devnet.md.

--- a/.env.sample
+++ b/.env.sample
@@ -63,3 +63,20 @@ UPDATE_BASELINES='false' # true auto-saves missing baseline screenshots
 # COMMUNITY_LINK=http://10.0.0.1:8080/local-devnet-community?public_key=aa7c2b3bcd6433e52d6616356fcdba68668e8b506d84a3c7a1a196d63235a613
 # COMMUNITY_NAME=Local Devnet Community
 # COMMUNITY_ROOM=local-devnet-community
+
+# With COMMUNITY_LINK set, each community test creates rooms of its own and deletes them afterwards,
+# so concurrent runs (CI and a laptop, or two CI jobs) can't interfere. Creating a room has no HTTP
+# endpoint in PySOGS, so it goes through Sesh-Net-Docker's room.sh, which shells into the container.
+#
+# Defaults to a Sesh-Net-Docker checkout sitting alongside this repo; set this when yours is
+# elsewhere. Checked once at startup by listing rooms — if that doesn't work (no CLI, no docker,
+# container down) the run falls back to the shared rooms with a loud warning rather than failing,
+# since that still tests everything, just without isolating concurrent runs.
+# SOGS_ROOM_CLI=/path/to/Sesh-Net-Docker/sogs/room.sh
+#
+# Alternative to the CLI, for machines that can reach the SOGS container over the network but can't
+# `docker exec` into it (a CI runner whose devnet is on another host). Sesh-Net-Docker's sogs
+# container exposes the same create/delete/gc operations on :8081 when its SOGS_ROOM_API_TOKEN is
+# set; give the same token here. Takes precedence over SOGS_ROOM_CLI when set.
+# SOGS_ROOM_API=http://10.0.0.1:8081
+# SOGS_ROOM_API_TOKEN=<same value as the container's SOGS_ROOM_API_TOKEN>

--- a/docs/local-devnet.md
+++ b/docs/local-devnet.md
@@ -228,38 +228,36 @@ somewhere unrelated to the cause.
 
 Mechanics worth knowing:
 
-- **Creation goes through the container**, one way or another. PySOGS has no room-creation endpoint
-  (`PUT /room/<token>` only updates), so it has to happen inside SOGS. Two transports:
-  - **`sogs/room.sh`** (default) — `docker exec`s in. Needs a local Docker daemon. The default path
-    assumes Sesh-Net-Docker sits alongside this repo; set `SOGS_ROOM_CLI` when it doesn't.
-  - **`SOGS_ROOM_API`** + `SOGS_ROOM_API_TOKEN` — the same operations over HTTP, for machines that can
-    reach the container but can't `docker exec` into it. Takes precedence when set. The container side
-    is `sogs/room_api.py`, which only listens when its own `SOGS_ROOM_API_TOKEN` is set; give the
-    harness the same value. The `qa-` prefix rule and the gc TTL are enforced **server-side** in both
-    cases, so the transport can't be a way around them.
-- **Availability is decided once, at startup.** `global-setup.ts` runs `room.sh list`; if that fails —
-  no CLI, no docker, container down — the run **falls back to the shared rooms with a loud warning**
-  rather than failing, since that configuration still tests everything, just without isolating
-  concurrent runs. The check is the CLI rather than SOGS' HTTP API on purpose: a reachable SOGS says
-  nothing about whether rooms can be _created_, which is precisely the CI case. The answer is cached
-  in the environment, so per-test lookups stay cheap and every caller agrees.
+- **Everything goes through SOGS' own HTTP API** — `POST /rooms`, `DELETE /room/<token>`, and
+  `GET /rooms` — so nothing here needs shell or Docker access to the machine running SOGS. That is what
+  lets CI use it: the runner is a different host from the devnet.
+- **Requests are signed as `SOGS_ADMIN_SEED`**, which must be a global admin (locally it is, by
+  default). SOGS requires _blinded_ ids, so the signing is not plain Ed25519 over the account key — see
+  `run/test/utils/sogs_auth.ts`, which mirrors what the clients do.
+- **Availability is decided once, at startup.** `global-setup.ts` lists rooms; if that fails — SOGS
+  unreachable, the account not a global admin, a server too old to have the endpoints — the run **falls
+  back to the shared rooms with a loud warning** rather than failing, since that configuration still
+  tests everything, just without isolating concurrent runs. Listing is the check because it exercises
+  everything creating a room needs, while changing nothing. The answer is cached in the environment, so
+  per-test lookups stay cheap and every caller agrees.
+- **A new room is seeded with one message.** SOGS creates rooms empty, and `joinCommunity` waits for a
+  message body, so a client joining an empty room _hangs_ rather than failing. The message is a real
+  protobuf `Content`, signed by a throwaway per-room identity rather than the admin's — SOGS takes a
+  user's display name from the messages they post, so seeding as the admin would rename it in every
+  room. See `run/test/utils/sogs_seed_message.ts`.
 - **Tokens are `qa-<runId>-w<worker>-<n>`.** `QA_RUN_ID` is stamped once per run in `global-setup.ts`,
-  so concurrent runs can't pick the same token and delete each other's rooms. The `qa-` prefix is what
-  marks a room disposable — `room.py` refuses to delete anything without it, so the six static rooms
-  are safe.
+  so concurrent runs can't pick the same token and delete each other's rooms. The `qa-` prefix marks a
+  room disposable, and since SOGS has no notion of a temporary room that rule lives in the harness —
+  every delete path asserts it, so the six static rooms are safe from a bug pointing a delete at them.
 - **Rooms are released in `sessionIt`'s `finally`**, so a failing test still cleans up. Anything missed
   (a timeout or an interrupt skips that block) is collected by the `gc` sweep `global-setup.ts` runs at
   the start of the next run, which only removes `qa-` rooms older than its TTL — comfortably longer
   than any single test, so it can't delete a room out from under a concurrent run.
-- **The link is rebuilt from `COMMUNITY_LINK`'s origin.** `room.py` prints a link built from the
-  server's own `URL_BASE`, which is `localhost` and unreachable from a simulator.
+- **The link is rebuilt from `COMMUNITY_LINK`'s origin**, since the server's own idea of its address is
+  `localhost` and unreachable from a simulator.
 
-> **CI:** off by default and the fallback handles it — `docker exec` is local, the runner is not the
-> devnet host, so the CLI check fails and the run uses the shared rooms. To turn them on, set
-> `SOGS_ROOM_API_TOKEN` on the devnet's sogs container (which starts the API on `:8081`) and give the
-> runner `SOGS_ROOM_API=http://<devnet-host>:8081` plus the same token. No Docker access or SSH keys
-> needed. Keep that port off public networks: the token guards against accidents, it is not access
-> control.
+> **Server version:** `POST /rooms` and `DELETE /room/<token>` are additions to session-pysogs — a SOGS
+> without them fails the startup check and the run falls back to the shared rooms, naming the reason.
 
 ## 5. Run
 

--- a/docs/local-devnet.md
+++ b/docs/local-devnet.md
@@ -204,6 +204,63 @@ Notes:
   reach out to any remote community. The room count is fixed at 6 (`LOCAL_COMMUNITY_COUNT` in
   `run/constants/community.ts`, matching `ROOM_COUNT` in the SOGS `entrypoint.sh`).
 
+### Per-test rooms
+
+With `COMMUNITY_LINK` set, the six rooms above stop being what the tests actually use: each community
+test creates rooms of its own and deletes them afterwards. Two runs against the same SOGS — CI and a
+laptop, or two CI jobs — therefore can't join, post, pin or ban in the same place, and a test is free
+to leave its rooms in whatever state it likes.
+
+A test opts in by declaring how many it needs:
+
+```ts
+iosIt({
+  title: 'Join community test',
+  communityRooms: 1, // becomes communities.testCommunity
+  ...
+});
+```
+
+`communities` resolves per test, so `communityRooms: 2` gives `testCommunity` and `community2`.
+Reading `communities` **without** declaring `communityRooms` throws rather than falling back to a
+shared room — a silent fallback is how tests start interfering again, and the failure would surface
+somewhere unrelated to the cause.
+
+Mechanics worth knowing:
+
+- **Creation goes through the container**, one way or another. PySOGS has no room-creation endpoint
+  (`PUT /room/<token>` only updates), so it has to happen inside SOGS. Two transports:
+  - **`sogs/room.sh`** (default) — `docker exec`s in. Needs a local Docker daemon. The default path
+    assumes Sesh-Net-Docker sits alongside this repo; set `SOGS_ROOM_CLI` when it doesn't.
+  - **`SOGS_ROOM_API`** + `SOGS_ROOM_API_TOKEN` — the same operations over HTTP, for machines that can
+    reach the container but can't `docker exec` into it. Takes precedence when set. The container side
+    is `sogs/room_api.py`, which only listens when its own `SOGS_ROOM_API_TOKEN` is set; give the
+    harness the same value. The `qa-` prefix rule and the gc TTL are enforced **server-side** in both
+    cases, so the transport can't be a way around them.
+- **Availability is decided once, at startup.** `global-setup.ts` runs `room.sh list`; if that fails —
+  no CLI, no docker, container down — the run **falls back to the shared rooms with a loud warning**
+  rather than failing, since that configuration still tests everything, just without isolating
+  concurrent runs. The check is the CLI rather than SOGS' HTTP API on purpose: a reachable SOGS says
+  nothing about whether rooms can be _created_, which is precisely the CI case. The answer is cached
+  in the environment, so per-test lookups stay cheap and every caller agrees.
+- **Tokens are `qa-<runId>-w<worker>-<n>`.** `QA_RUN_ID` is stamped once per run in `global-setup.ts`,
+  so concurrent runs can't pick the same token and delete each other's rooms. The `qa-` prefix is what
+  marks a room disposable — `room.py` refuses to delete anything without it, so the six static rooms
+  are safe.
+- **Rooms are released in `sessionIt`'s `finally`**, so a failing test still cleans up. Anything missed
+  (a timeout or an interrupt skips that block) is collected by the `gc` sweep `global-setup.ts` runs at
+  the start of the next run, which only removes `qa-` rooms older than its TTL — comfortably longer
+  than any single test, so it can't delete a room out from under a concurrent run.
+- **The link is rebuilt from `COMMUNITY_LINK`'s origin.** `room.py` prints a link built from the
+  server's own `URL_BASE`, which is `localhost` and unreachable from a simulator.
+
+> **CI:** off by default and the fallback handles it — `docker exec` is local, the runner is not the
+> devnet host, so the CLI check fails and the run uses the shared rooms. To turn them on, set
+> `SOGS_ROOM_API_TOKEN` on the devnet's sogs container (which starts the API on `:8081`) and give the
+> runner `SOGS_ROOM_API=http://<devnet-host>:8081` plus the same token. No Docker access or SSH keys
+> needed. Keep that port off public networks: the token guards against accidents, it is not access
+> control.
+
 ## 5. Run
 
 ```bash

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -1,4 +1,5 @@
 import { FullConfig } from '@playwright/test';
+import { v4 as uuidv4 } from 'uuid';
 
 import { getDevicesPerTestCount, getWorkersCount } from './run/test/utils/binaries';
 import { gcCommunityRooms, probePerTestRooms } from './run/test/utils/community_rooms';
@@ -37,9 +38,7 @@ export default async function globalSetup(_config: FullConfig) {
   // Stamped once per run and read by the per-test community room allocator to build tokens that
   // can't collide with a run happening at the same time elsewhere. Set here rather than per-worker
   // because workers inherit this process's env, and they each need the same value.
-  process.env.QA_RUN_ID = `${Date.now().toString(36)}${Math.floor(Math.random() * 1e4)
-    .toString(36)
-    .padStart(3, '0')}`;
+  process.env.QA_RUN_ID = uuidv4();
 
   // Decided once here rather than per test: the check shells out, and every `communities` lookup asks
   // whether per-test rooms are on, so it has to be a cheap read by then. Workers inherit the answer

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -1,6 +1,7 @@
 import { FullConfig } from '@playwright/test';
 
 import { getDevicesPerTestCount, getWorkersCount } from './run/test/utils/binaries';
+import { gcCommunityRooms, probePerTestRooms } from './run/test/utils/community_rooms';
 import { getNetworkTarget } from './run/test/utils/devnet';
 import { SupportedPlatformsType } from './run/test/utils/open_app';
 import { ensureWdaBuilt } from './scripts/build_wda';
@@ -32,6 +33,22 @@ const PREPARED_FLAG = 'IOS_SIMULATORS_PREPARED';
 
 export default async function globalSetup(_config: FullConfig) {
   const platform = process.env.PLATFORM as SupportedPlatformsType | undefined;
+
+  // Stamped once per run and read by the per-test community room allocator to build tokens that
+  // can't collide with a run happening at the same time elsewhere. Set here rather than per-worker
+  // because workers inherit this process's env, and they each need the same value.
+  process.env.QA_RUN_ID = `${Date.now().toString(36)}${Math.floor(Math.random() * 1e4)
+    .toString(36)
+    .padStart(3, '0')}`;
+
+  // Decided once here rather than per test: the check shells out, and every `communities` lookup asks
+  // whether per-test rooms are on, so it has to be a cheap read by then. Workers inherit the answer
+  // through this process's env. Falls back to the shared rooms (loudly) when rooms can't be created.
+  await probePerTestRooms();
+
+  // Collect rooms orphaned by runs that were killed before their teardown ran. The TTL keeps this
+  // clear of anything a concurrent run is still using.
+  await gcCommunityRooms();
 
   if (platform) {
     console.log(`Validating build/network configuration...`);

--- a/run/constants/community.ts
+++ b/run/constants/community.ts
@@ -87,9 +87,10 @@ const STATIC_COMMUNITIES: Record<string, CommunityConfig> = process.env.COMMUNIT
 /**
  * The community set for the current test.
  *
- * Against a local SOGS each test allocates rooms of its own (see utils/community_rooms.ts), so this
- * has to resolve when it's read rather than when the module loads. Against the shared remote
- * communities nothing can be created, so it stays the fixed list it always was.
+ * A function rather than an exported object because against a local SOGS each test allocates rooms of
+ * its own (see utils/community_rooms.ts), so the answer differs per test and has to be resolved when
+ * it's read. Against the shared remote communities nothing can be created, so it stays the fixed list
+ * it always was.
  *
  * Reading `testCommunity` from a test that didn't declare `communityRooms` is a mistake rather than
  * a fallback: silently handing back a shared room is how tests end up interfering again, and the
@@ -111,16 +112,3 @@ export function getCommunities(): Record<string, CommunityConfig> {
     rooms.map((room, index) => [index === 0 ? 'testCommunity' : `community${index + 1}`, room])
   );
 }
-
-export const communities: Record<string, CommunityConfig> = new Proxy(
-  {},
-  {
-    get: (_target, key: string) => getCommunities()[key],
-    ownKeys: () => Reflect.ownKeys(getCommunities()),
-    getOwnPropertyDescriptor: (_target, key: string) => ({
-      value: getCommunities()[key],
-      enumerable: true,
-      configurable: true,
-    }),
-  }
-) as Record<string, CommunityConfig>;

--- a/run/constants/community.ts
+++ b/run/constants/community.ts
@@ -1,5 +1,7 @@
 import dotenv from 'dotenv';
 
+import { getAllocatedRooms, perTestRoomsEnabled } from '../test/utils/community_rooms';
+
 dotenv.config({ quiet: true });
 
 type CommunityConfig = {
@@ -78,6 +80,47 @@ const REMOTE_COMMUNITIES: Record<string, CommunityConfig> = {
   },
 };
 
-export const communities: Record<string, CommunityConfig> = process.env.COMMUNITY_LINK
+const STATIC_COMMUNITIES: Record<string, CommunityConfig> = process.env.COMMUNITY_LINK
   ? buildLocalCommunities(process.env.COMMUNITY_LINK)
   : REMOTE_COMMUNITIES;
+
+/**
+ * The community set for the current test.
+ *
+ * Against a local SOGS each test allocates rooms of its own (see utils/community_rooms.ts), so this
+ * has to resolve when it's read rather than when the module loads. Against the shared remote
+ * communities nothing can be created, so it stays the fixed list it always was.
+ *
+ * Reading `testCommunity` from a test that didn't declare `communityRooms` is a mistake rather than
+ * a fallback: silently handing back a shared room is how tests end up interfering again, and the
+ * failure would surface somewhere unrelated. So it throws, naming what to add.
+ */
+export function getCommunities(): Record<string, CommunityConfig> {
+  if (!perTestRoomsEnabled()) {
+    return STATIC_COMMUNITIES;
+  }
+
+  const rooms = getAllocatedRooms();
+  if (rooms.length === 0) {
+    throw new Error(
+      'No community rooms allocated for this test. Add `communityRooms: <n>` to its sessionIt declaration.'
+    );
+  }
+
+  return Object.fromEntries(
+    rooms.map((room, index) => [index === 0 ? 'testCommunity' : `community${index + 1}`, room])
+  );
+}
+
+export const communities: Record<string, CommunityConfig> = new Proxy(
+  {},
+  {
+    get: (_target, key: string) => getCommunities()[key],
+    ownKeys: () => Reflect.ownKeys(getCommunities()),
+    getOwnPropertyDescriptor: (_target, key: string) => ({
+      value: getCommunities()[key],
+      enumerable: true,
+      configurable: true,
+    }),
+  }
+) as Record<string, CommunityConfig>;

--- a/run/test/locators/conversation.ts
+++ b/run/test/locators/conversation.ts
@@ -1,6 +1,6 @@
 import type { DeviceWrapper } from '../../types/DeviceWrapper';
 
-import { communities } from '../../constants/community';
+import { getCommunities } from '../../constants/community';
 import { tStripped } from '../../localizer/lib';
 import { StrategyExtractionObj } from '../../types/testing';
 import { getAppDisplayName } from '../utils/devnet';
@@ -64,13 +64,13 @@ export class CommunityInvitation extends LocatorsInterface {
         return {
           strategy: 'id',
           selector: 'network.loki.messenger:id/openGroupTitleTextView',
-          text: communities.testCommunity.name,
+          text: getCommunities().testCommunity.name,
         } as const;
       case 'ios':
         return {
           strategy: 'accessibility id',
           selector: 'Community invitation',
-          text: communities.testCommunity.name,
+          text: getCommunities().testCommunity.name,
         } as const;
     }
   }

--- a/run/test/specs/mobile/community_ban.spec.ts
+++ b/run/test/specs/mobile/community_ban.spec.ts
@@ -1,6 +1,6 @@
 import test, { type TestInfo } from '@playwright/test';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { tStripped } from '../../../localizer/lib';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
@@ -49,6 +49,7 @@ bothPlatformsIt({
 });
 
 async function banUserCommunity(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   assertAdminIsKnown();
   const msgSig = `${new Date().getTime()} - ${platform}`;
   const msg1 = `Ban and unban me - ${msgSig}`;
@@ -117,6 +118,7 @@ async function banUserCommunity(platform: SupportedPlatformsType, testInfo: Test
 }
 
 async function banAndDelete(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   assertAdminIsKnown();
   const msgSig = `${new Date().getTime()} - ${platform}`;
   const msg1 = `Ban and delete - ${msgSig}`;

--- a/run/test/specs/mobile/community_ban.spec.ts
+++ b/run/test/specs/mobile/community_ban.spec.ts
@@ -23,6 +23,7 @@ bothPlatformsIt({
   title: 'Ban and unban user in community',
   risk: 'medium',
   countOfDevicesNeeded: 2,
+  communityRooms: 1,
   testCb: banUserCommunity,
   allureSuites: {
     parent: 'User Actions',
@@ -37,6 +38,7 @@ bothPlatformsIt({
   title: 'Ban and delete in community',
   risk: 'medium',
   countOfDevicesNeeded: 2,
+  communityRooms: 1,
   testCb: banAndDelete,
   allureSuites: {
     parent: 'User Actions',

--- a/run/test/specs/mobile/community_emoji_react.spec.ts
+++ b/run/test/specs/mobile/community_emoji_react.spec.ts
@@ -1,6 +1,6 @@
 import { test, type TestInfo } from '@playwright/test';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
 import { EmojiReactsPill, FirstEmojiReact, MessageBody } from '../../locators/conversation';
@@ -22,6 +22,7 @@ bothPlatformsIt({
 });
 
 async function sendEmojiReactionCommunity(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const message = `Testing emoji reacts - ${new Date().getTime()} - ${platform}`;
   const {
     devices: { alice1, bob1 },

--- a/run/test/specs/mobile/community_emoji_react.spec.ts
+++ b/run/test/specs/mobile/community_emoji_react.spec.ts
@@ -12,6 +12,7 @@ bothPlatformsIt({
   title: 'Send emoji react community',
   risk: 'medium',
   countOfDevicesNeeded: 2,
+  communityRooms: 1,
   testCb: sendEmojiReactionCommunity,
   allureSuites: {
     parent: 'Sending Messages',

--- a/run/test/specs/mobile/community_links.spec.ts
+++ b/run/test/specs/mobile/community_links.spec.ts
@@ -1,7 +1,7 @@
 import { test, TestInfo } from '@playwright/test';
 import { USERNAME } from '@session-foundation/qa-seeder';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { tStripped } from '../../../localizer/lib';
 import { TestSteps } from '../../../types/allure';
 import { androidIt } from '../../../types/sessionIt';
@@ -72,6 +72,7 @@ androidIt({
 });
 
 async function communityURLNewConvo(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const { device } = await test.step(TestSteps.SETUP.NEW_USER, async () => {
     const { device } = await openAppOnPlatformSingleDevice(platform, testInfo);
     await newUser(device, USERNAME.ALICE, { saveUserData: false });
@@ -102,6 +103,7 @@ async function communityURLNewConvo(platform: SupportedPlatformsType, testInfo: 
 }
 
 async function communityURLGroup(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const { device } = await test.step(TestSteps.SETUP.NEW_USER, async () => {
     const { device } = await openAppOnPlatformSingleDevice(platform, testInfo);
     await newUser(device, USERNAME.ALICE, { saveUserData: false });
@@ -132,6 +134,7 @@ async function communityURLGroup(platform: SupportedPlatformsType, testInfo: Tes
 }
 
 async function communityURLNewConvoMember(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const { device } = await test.step(TestSteps.SETUP.NEW_USER, async () => {
     const { device } = await openAppOnPlatformSingleDevice(platform, testInfo);
     await newUser(device, USERNAME.ALICE, { saveUserData: false });
@@ -169,6 +172,7 @@ async function communityURLNewConvoMember(platform: SupportedPlatformsType, test
 }
 
 async function communityURLGroupMember(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const { device } = await test.step(TestSteps.SETUP.NEW_USER, async () => {
     const { device } = await openAppOnPlatformSingleDevice(platform, testInfo);
     await newUser(device, USERNAME.ALICE, { saveUserData: false });

--- a/run/test/specs/mobile/community_links.spec.ts
+++ b/run/test/specs/mobile/community_links.spec.ts
@@ -27,6 +27,7 @@ androidIt({
   title: 'Community URL on New Message - not member',
   risk: 'low',
   countOfDevicesNeeded: 1,
+  communityRooms: 1,
   testCb: communityURLNewConvo,
   allureSuites: {
     parent: 'New Conversation',
@@ -38,6 +39,7 @@ androidIt({
   title: 'Join Community URL on Create Group - not member',
   risk: 'low',
   countOfDevicesNeeded: 1,
+  communityRooms: 1,
   testCb: communityURLGroup,
   allureSuites: {
     parent: 'New Conversation',
@@ -49,6 +51,7 @@ androidIt({
   title: 'Community URL on New Message - member',
   risk: 'low',
   countOfDevicesNeeded: 1,
+  communityRooms: 1,
   testCb: communityURLNewConvoMember,
   allureSuites: {
     parent: 'New Conversation',
@@ -60,6 +63,7 @@ androidIt({
   title: 'Join Community URL on Create Group - member',
   risk: 'low',
   countOfDevicesNeeded: 1,
+  communityRooms: 1,
   testCb: communityURLGroupMember,
   allureSuites: {
     parent: 'New Conversation',

--- a/run/test/specs/mobile/community_requests_off.spec.ts
+++ b/run/test/specs/mobile/community_requests_off.spec.ts
@@ -14,6 +14,7 @@ bothPlatformsIt({
   risk: 'medium',
   testCb: blindedMessageRequests,
   countOfDevicesNeeded: 2,
+  communityRooms: 1,
   allureSuites: { parent: 'Settings', suite: 'Privacy' },
   allureDescription:
     'Verifies that a message request cannot be sent when Community Message Requests are off.',

--- a/run/test/specs/mobile/community_requests_off.spec.ts
+++ b/run/test/specs/mobile/community_requests_off.spec.ts
@@ -1,7 +1,7 @@
 import { test, type TestInfo } from '@playwright/test';
 import { USERNAME } from '@session-foundation/qa-seeder';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
 import { CommunityMessageAuthor, UPMMessageButton } from '../../locators/conversation';
@@ -21,6 +21,7 @@ bothPlatformsIt({
 });
 
 async function blindedMessageRequests(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const message = `I do not accept blinded message requests + ${platform} + ${Date.now()}`;
   const { device1, device2 } = await test.step(TestSteps.SETUP.NEW_USER, async () => {
     const { device1, device2 } = await openAppTwoDevices(platform, testInfo);

--- a/run/test/specs/mobile/community_requests_on.spec.ts
+++ b/run/test/specs/mobile/community_requests_on.spec.ts
@@ -1,7 +1,7 @@
 import { test, type TestInfo } from '@playwright/test';
 import { USERNAME } from '@session-foundation/qa-seeder';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
 import { CloseSettings } from '../../locators';
@@ -39,6 +39,7 @@ bothPlatformsIt({
 });
 
 async function blindedMessageRequests(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const message = `I accept blinded message requests + ${platform} + ${Date.now()}`;
   const messageRequestMessage = 'Howdy';
   const messageRequestReply = 'Howdy back';

--- a/run/test/specs/mobile/community_requests_on.spec.ts
+++ b/run/test/specs/mobile/community_requests_on.spec.ts
@@ -29,6 +29,7 @@ bothPlatformsIt({
   risk: 'medium',
   testCb: blindedMessageRequests,
   countOfDevicesNeeded: 2,
+  communityRooms: 1,
   allureSuites: { parent: 'Settings', suite: 'Privacy' },
   allureDescription:
     'Verifies that a message request can be sent when Community Message Requests are on.',

--- a/run/test/specs/mobile/community_tests_image.spec.ts
+++ b/run/test/specs/mobile/community_tests_image.spec.ts
@@ -1,6 +1,6 @@
 import { test, type TestInfo } from '@playwright/test';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
 import { MessageBody } from '../../locators/conversation';
@@ -20,6 +20,7 @@ bothPlatformsIt({
 });
 
 async function sendImageCommunity(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const {
     devices: { alice1, bob1 },
   } = await test.step(TestSteps.SETUP.QA_SEEDER, async () => {

--- a/run/test/specs/mobile/community_tests_image.spec.ts
+++ b/run/test/specs/mobile/community_tests_image.spec.ts
@@ -13,6 +13,7 @@ bothPlatformsIt({
   title: 'Send image to community',
   risk: 'medium',
   countOfDevicesNeeded: 2,
+  communityRooms: 1,
   testCb: sendImageCommunity,
   allureSuites: { parent: 'Sending Messages', suite: 'Message types' },
   allureDescription: 'Verifies that an image can be sent and received in a community',

--- a/run/test/specs/mobile/community_tests_join.spec.ts
+++ b/run/test/specs/mobile/community_tests_join.spec.ts
@@ -1,6 +1,6 @@
 import { test, type TestInfo } from '@playwright/test';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
 import { ConversationItem } from '../../locators/home';
@@ -23,6 +23,7 @@ bothPlatformsIt({
 });
 
 async function joinCommunityTest(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const {
     devices: { alice1, alice2 },
     prebuilt: { alice },

--- a/run/test/specs/mobile/community_tests_join.spec.ts
+++ b/run/test/specs/mobile/community_tests_join.spec.ts
@@ -13,6 +13,7 @@ bothPlatformsIt({
   risk: 'high',
   testCb: joinCommunityTest,
   countOfDevicesNeeded: 2,
+  communityRooms: 1,
   allureSuites: {
     parent: 'New Conversation',
     suite: 'Join Community',

--- a/run/test/specs/mobile/disappearing_community_invite.spec.ts
+++ b/run/test/specs/mobile/disappearing_community_invite.spec.ts
@@ -1,6 +1,6 @@
 import type { TestInfo } from '@playwright/test';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { bothPlatformsIt } from '../../../types/sessionIt';
 import { DISAPPEARING_TIMES } from '../../../types/testing';
 import { InviteContactsMenuItem } from '../../locators';
@@ -43,6 +43,7 @@ async function disappearingCommunityInviteMessage(
   platform: SupportedPlatformsType,
   testInfo: TestInfo
 ) {
+  const communities = getCommunities();
   const {
     devices: { alice1, bob1 },
     prebuilt: { bob },

--- a/run/test/specs/mobile/disappearing_community_invite.spec.ts
+++ b/run/test/specs/mobile/disappearing_community_invite.spec.ts
@@ -24,6 +24,7 @@ bothPlatformsIt({
   title: 'Disappearing community invite message 1:1',
   risk: 'low',
   countOfDevicesNeeded: 2,
+  communityRooms: 1,
   testCb: disappearingCommunityInviteMessage,
   allureSuites: {
     parent: 'Disappearing Messages',

--- a/run/test/specs/mobile/linked_device_community_ban.spec.ts
+++ b/run/test/specs/mobile/linked_device_community_ban.spec.ts
@@ -1,6 +1,6 @@
 import test, { type TestInfo } from '@playwright/test';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { tStripped } from '../../../localizer/lib';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
@@ -54,6 +54,7 @@ bothPlatformsIt({
 
 // Bob 1 + Bob 2 get banned by Alice the admin
 async function banUnbanLinked(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   assertAdminIsKnown();
   const msgSig = `${new Date().getTime()} - ${platform}`;
   const msg1 = `Ban, link, unban - ${msgSig}`;
@@ -126,6 +127,7 @@ async function banUnbanLinked(platform: SupportedPlatformsType, testInfo: TestIn
 
 // Bob 1 + Bob 2 get banned by Alice the admin
 async function banAndDeleteLinked(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   assertAdminIsKnown();
   const msgSig = `${new Date().getTime()} - ${platform}`;
   const msg1 = `Ban and delete linked - ${msgSig}`;

--- a/run/test/specs/mobile/linked_device_community_ban.spec.ts
+++ b/run/test/specs/mobile/linked_device_community_ban.spec.ts
@@ -25,6 +25,7 @@ bothPlatformsIt({
   title: 'Ban and unban user in community - linked device',
   risk: 'medium',
   countOfDevicesNeeded: 3,
+  communityRooms: 1,
   testCb: banUnbanLinked,
   allureSuites: {
     parent: 'User Actions',
@@ -40,6 +41,7 @@ bothPlatformsIt({
   title: 'Ban and delete in community - linked device',
   risk: 'medium',
   countOfDevicesNeeded: 3,
+  communityRooms: 1,
   testCb: banAndDeleteLinked,
   allureSuites: {
     parent: 'User Actions',

--- a/run/test/specs/mobile/message_community_invitation.spec.ts
+++ b/run/test/specs/mobile/message_community_invitation.spec.ts
@@ -1,6 +1,6 @@
 import type { TestInfo } from '@playwright/test';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { tStripped } from '../../../localizer/lib';
 import { bothPlatformsIt } from '../../../types/sessionIt';
 import { InviteContactsMenuItem, JoinCommunityModalButton } from '../../locators';
@@ -27,6 +27,7 @@ bothPlatformsIt({
 });
 
 async function sendCommunityInvitation(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const {
     devices: { alice1, bob1 },
     prebuilt: { bob },

--- a/run/test/specs/mobile/message_community_invitation.spec.ts
+++ b/run/test/specs/mobile/message_community_invitation.spec.ts
@@ -22,6 +22,7 @@ bothPlatformsIt({
   title: 'Send community invitation',
   risk: 'medium',
   countOfDevicesNeeded: 2,
+  communityRooms: 1,
   testCb: sendCommunityInvitation,
 });
 

--- a/run/test/specs/mobile/qr_codes.spec.ts
+++ b/run/test/specs/mobile/qr_codes.spec.ts
@@ -49,6 +49,7 @@ androidIt({
   risk: 'medium',
   testCb: qrCodeCommunity,
   countOfDevicesNeeded: 2,
+  communityRooms: 1,
   allureSuites: {
     parent: 'New Conversation',
     suite: 'Join Community',

--- a/run/test/specs/mobile/qr_codes.spec.ts
+++ b/run/test/specs/mobile/qr_codes.spec.ts
@@ -1,6 +1,6 @@
 import { test, type TestInfo } from '@playwright/test';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { TestSteps } from '../../../types/allure';
 import { androidIt } from '../../../types/sessionIt';
 import { InteractionPoints, USERNAME } from '../../../types/testing';
@@ -128,6 +128,7 @@ async function qrCodeAccountID(platform: SupportedPlatformsType, testInfo: TestI
 }
 
 async function qrCodeCommunity(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const {
     devices: { alice1, bob1 },
     prebuilt: { bob },

--- a/run/test/specs/mobile/recovery_banner.spec.ts
+++ b/run/test/specs/mobile/recovery_banner.spec.ts
@@ -20,6 +20,7 @@ androidIt({
   risk: 'medium',
   testCb: bannerShowsThreeConvos,
   countOfDevicesNeeded: 1,
+  communityRooms: 3,
   allureSuites: {
     parent: 'Settings',
     suite: 'Recovery Password',
@@ -33,6 +34,7 @@ androidIt({
   risk: 'medium',
   testCb: bannerDisappearsAfterOpened,
   countOfDevicesNeeded: 1,
+  communityRooms: 3,
   allureSuites: {
     parent: 'Settings',
     suite: 'Recovery Password',
@@ -45,6 +47,7 @@ androidIt({
   risk: 'medium',
   testCb: bannerPersists,
   countOfDevicesNeeded: 1,
+  communityRooms: 3,
   allureSuites: {
     parent: 'Settings',
     suite: 'Recovery Password',

--- a/run/test/specs/mobile/recovery_banner.spec.ts
+++ b/run/test/specs/mobile/recovery_banner.spec.ts
@@ -1,7 +1,7 @@
 import { test, type TestInfo } from '@playwright/test';
 import { USERNAME } from '@session-foundation/qa-seeder';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { TestSteps } from '../../../types/allure';
 import { DeviceWrapper } from '../../../types/DeviceWrapper';
 import { androidIt } from '../../../types/sessionIt';
@@ -69,6 +69,7 @@ async function bannerShouldShow(device: DeviceWrapper) {
 }
 
 async function bannerShowsThreeConvos(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const { device } = await test.step(TestSteps.SETUP.NEW_USER, async () => {
     const { device } = await openAppOnPlatformSingleDevice(platform, testInfo);
     await newUser(device, USERNAME.ALICE, { saveUserData: false });
@@ -107,6 +108,7 @@ async function bannerDisappearsAfterOpened(platform: SupportedPlatformsType, tes
 }
 
 async function bannerPersists(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const { device } = await test.step(TestSteps.SETUP.NEW_USER, async () => {
     const { device } = await openAppOnPlatformSingleDevice(platform, testInfo);
     await newUser(device, USERNAME.ALICE, { saveUserData: false });

--- a/run/test/specs/mobile/user_actions_pin_unpin.spec.ts
+++ b/run/test/specs/mobile/user_actions_pin_unpin.spec.ts
@@ -1,7 +1,7 @@
 import { test, type TestInfo } from '@playwright/test';
 import { USERNAME } from '@session-foundation/qa-seeder';
 
-import { communities } from '../../../constants/community';
+import { getCommunities } from '../../../constants/community';
 import { TestSteps } from '../../../types/allure';
 import { bothPlatformsIt } from '../../../types/sessionIt';
 import { ConversationPinnedIcon, PlusButton } from '../../locators/home';
@@ -104,6 +104,7 @@ async function pinConversation(platform: SupportedPlatformsType, testInfo: TestI
 }
 
 async function nonProPinnedLimit(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const numCommunities = 6;
   const { device } = await test.step(TestSteps.SETUP.NEW_USER, async () => {
     const { device } = await openAppOnPlatformSingleDevice(platform, testInfo, IOS_PRO_CONTEXT);
@@ -137,6 +138,7 @@ async function nonProPinnedLimit(platform: SupportedPlatformsType, testInfo: Tes
 }
 
 async function proPinnedLimit(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  const communities = getCommunities();
   const numCommunities = 6;
   const { device, alice } = await test.step(TestSteps.SETUP.NEW_USER, async () => {
     const { device } = await openAppOnPlatformSingleDevice(platform, testInfo, IOS_PRO_CONTEXT);

--- a/run/test/specs/mobile/user_actions_pin_unpin.spec.ts
+++ b/run/test/specs/mobile/user_actions_pin_unpin.spec.ts
@@ -22,6 +22,7 @@ bothPlatformsIt({
   risk: 'medium',
   testCb: pinConversation,
   countOfDevicesNeeded: 1,
+  communityRooms: 2,
   allureSuites: {
     parent: 'User Actions',
     suite: 'Pin/Unpin',
@@ -35,6 +36,7 @@ bothPlatformsIt({
   risk: 'high',
   testCb: nonProPinnedLimit,
   countOfDevicesNeeded: 1,
+  communityRooms: 6,
   isPro: true,
   allureSuites: {
     parent: 'Session Pro',
@@ -47,6 +49,7 @@ bothPlatformsIt({
   risk: 'high',
   testCb: proPinnedLimit,
   countOfDevicesNeeded: 1,
+  communityRooms: 6,
   isPro: true,
   allureSuites: {
     parent: 'Session Pro',

--- a/run/test/utils/community.ts
+++ b/run/test/utils/community.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test';
 
-import { communities } from '../../constants/community';
+import { getCommunities } from '../../constants/community';
 import { DeviceWrapper } from '../../types/DeviceWrapper';
 import { CommunityInput, JoinCommunityButton } from '../locators';
 import { ConversationHeaderName, MessageBody } from '../locators/conversation';
@@ -54,6 +54,7 @@ export const openOrJoinCommunity = async (
 };
 
 export const joinCommunities = async (device: DeviceWrapper, toJoin: number) => {
+  const communities = getCommunities();
   const available = Object.values(communities).length;
   if (toJoin > available) {
     throw new Error(

--- a/run/test/utils/community_rooms.ts
+++ b/run/test/utils/community_rooms.ts
@@ -119,7 +119,9 @@ function apiTransport(): RoomTransport {
         ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
       },
       method,
-      signal: AbortSignal.timeout(60_000),
+      // Create is the slowest operation and it seeds a message, so it isn't instant — but it has
+      // measured well under 2s, so this is a generous ceiling rather than an expected duration.
+      signal: AbortSignal.timeout(30_000),
     });
 
     const text = await response.text();
@@ -147,6 +149,10 @@ function apiTransport(): RoomTransport {
             `the same value as the sogs container's SOGS_ROOM_API_TOKEN`
         );
       }
+      // `GET /rooms` rather than the API's `/healthz`, deliberately: healthz is unauthenticated, so it
+      // proves only that something is listening. Listing rooms proves reachable *and* token accepted
+      // *and* database queryable — otherwise a wrong token passes the probe and fails on the first
+      // allocation instead. healthz stays useful for "is it up at all" without holding the token.
       await call('GET', '/rooms');
     },
     create: async (token, name) => void (await call('POST', '/rooms', { name, token })),
@@ -169,16 +175,21 @@ let allocated: CommunityRoom[] = [];
 let allocationCounter = 0;
 
 /**
- * Env var carrying the decision from global-setup to the workers, which inherit this process's env.
+ * Carries the decision from global-setup to the workers.
+ *
+ * An env var rather than a module-level boolean because **Playwright runs each worker in its own
+ * process**: `probePerTestRooms` runs once in the main process during global setup, and a variable set
+ * there would simply not exist in any worker. Workers inherit the environment of the process that
+ * spawned them, so this is the channel that crosses the boundary — the same mechanism QA_RUN_ID uses.
  */
 const ENABLED_FLAG = 'PER_TEST_COMMUNITY_ROOMS';
 
 /**
  * Whether this run allocates its own rooms.
  *
- * A cheap read of a decision made once by `probePerTestRooms` — deliberately not a check. This is
- * called on every `communities` property access, so it must not touch the filesystem or the network,
- * and every caller must agree: a test that allocated rooms and a `communities` lookup that decided
+ * A cheap read of a decision made once by `probePerTestRooms` — deliberately not a check. Every
+ * `getCommunities()` call asks this, so it must not touch the filesystem or the network, and every
+ * caller must agree: a test that allocated rooms alongside a `getCommunities()` call that decided
  * otherwise would read a shared room while believing it had its own.
  *
  * Defaults to off when the probe hasn't run, so anything importing this outside a test run gets the

--- a/run/test/utils/community_rooms.ts
+++ b/run/test/utils/community_rooms.ts
@@ -27,56 +27,142 @@ export type CommunityRoom = {
  * therefore safe: tests within a worker run one at a time.
  */
 
+/**
+ * How rooms are managed. Two implementations, differing only in how they reach SOGS — the room
+ * semantics, including the `qa-` prefix rule and the gc TTL, are enforced on the server either way.
+ *
+ * `gc` returns its own one-line summary rather than counts: the CLI already prints one, and parsing it
+ * back into numbers just to reformat it would be a brittle way to reach the same log line.
+ */
+type RoomTransport = {
+  create(token: string, name: string): Promise<void>;
+  /** Shown in the "per-test rooms enabled" line. */
+  readonly describe: string;
+  gc(olderThanSeconds: number): Promise<string>;
+  /** Rejects when rooms can't be managed. Used as the availability check by `probePerTestRooms`. */
+  check(): Promise<void>;
+  remove(token: string): Promise<void>;
+};
+
 // Default assumes Sesh-Net-Docker is checked out alongside this repo; override in .env when it isn't.
 const roomCliPath = () =>
   process.env.SOGS_ROOM_CLI ?? path.resolve(process.cwd(), '../Sesh-Net-Docker/sogs/room.sh');
 
-/**
- * The HTTP transport, used when SOGS_ROOM_API is set.
- *
- * `room.sh` needs a local Docker daemon, which the case this exists for doesn't have: a CI runner
- * driving a devnet on another host. Sesh-Net-Docker's sogs container can expose the same operations
- * on a port instead (`sogs/room_api.py`), so the choice here is purely about how we reach it — the
- * room semantics, including the `qa-` prefix rule, are enforced on the server either way.
- */
 const roomApiBase = () => (process.env.SOGS_ROOM_API ?? '').trim().replace(/\/$/, '');
-const useRoomApi = () => roomApiBase() !== '';
 const roomApiToken = () => (process.env.SOGS_ROOM_API_TOKEN ?? '').trim();
 
-async function callRoomApi(
-  method: 'DELETE' | 'GET' | 'POST',
-  route: string,
-  body?: unknown
-): Promise<unknown> {
-  const token = roomApiToken();
-  if (!token) {
-    // The probe checks for this up front and reports it properly; reaching it here would mean the
-    // token was cleared mid-run.
-    throw new Error('SOGS_ROOM_API_TOKEN is empty');
-  }
+/**
+ * Chosen from the environment once per process, then reused.
+ *
+ * Not chosen in `probePerTestRooms` and stored for everyone: workers are separate processes and
+ * inherit the env, not module state, so each derives this for itself. Deriving it once per process
+ * rather than per call is what stops four call sites disagreeing if the environment changes mid-run.
+ */
+let transport: RoomTransport | undefined;
 
-  const response = await fetch(`${roomApiBase()}${route}`, {
-    body: body === undefined ? undefined : JSON.stringify(body),
-    headers: {
-      Authorization: `Bearer ${token}`,
-      ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+function roomTransport(): RoomTransport {
+  transport ??= roomApiBase() === '' ? cliTransport() : apiTransport();
+  return transport;
+}
+
+/**
+ * Shells into the container via Sesh-Net-Docker's `room.sh`. The default when nothing else is
+ * configured, because it needs no token and no exposed port — with that repo checked out alongside
+ * this one it works with nothing set but COMMUNITY_LINK.
+ */
+function cliTransport(): RoomTransport {
+  const run = async (args: Array<string>): Promise<string> => {
+    const { stdout } = await execFileAsync(roomCliPath(), args, { timeout: 60_000 });
+    return stdout.trim();
+  };
+
+  return {
+    check: async () => {
+      const cli = roomCliPath();
+      if (!existsSync(cli)) {
+        throw new Error(
+          `no room CLI at ${cli} and SOGS_ROOM_API is unset. Point SOGS_ROOM_CLI at your ` +
+            `Sesh-Net-Docker checkout's sogs/room.sh, or set SOGS_ROOM_API + SOGS_ROOM_API_TOKEN`
+        );
+      }
+      await run(['list']);
     },
-    method,
-    signal: AbortSignal.timeout(60_000),
-  });
+    create: async (token, name) => void (await run(['create', token, '--name', name])),
+    describe: `room CLI at ${roomCliPath()}`,
+    gc: async olderThanSeconds =>
+      (await run(['gc', '--older-than', String(olderThanSeconds)])).split('\n')[0],
+    remove: async token => void (await run(['delete', token])),
+  };
+}
 
-  const text = await response.text();
-  if (!response.ok) {
-    // The API answers refusals as JSON `{error}`; surface that rather than a bare status.
-    let detail = text;
-    try {
-      detail = (JSON.parse(text) as { error?: string }).error ?? text;
-    } catch {
-      // Not JSON — a proxy or the wrong port. The raw body is more use than a parse error.
+/**
+ * Talks to `sogs/room_api.py` over HTTP. For hosts that can reach the SOGS container but can't
+ * `docker exec` into it — a CI runner driving a devnet that lives on another host. Takes precedence
+ * when SOGS_ROOM_API is set, since it is the deliberate choice of the two.
+ */
+function apiTransport(): RoomTransport {
+  const call = async (
+    method: 'DELETE' | 'GET' | 'POST',
+    route: string,
+    body?: unknown
+  ): Promise<unknown> => {
+    const token = roomApiToken();
+    if (!token) {
+      // `check` reports this properly; reaching it here would mean the token was cleared mid-run.
+      throw new Error('SOGS_ROOM_API_TOKEN is empty');
     }
-    throw new Error(`room API ${method} ${route} failed (HTTP ${response.status}): ${detail}`);
-  }
-  return text === '' ? {} : (JSON.parse(text) as unknown);
+
+    const response = await fetch(`${roomApiBase()}${route}`, {
+      body: body === undefined ? undefined : JSON.stringify(body),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+      },
+      method,
+      signal: AbortSignal.timeout(60_000),
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+      // The API answers refusals as JSON `{error}`; surface that rather than a bare status.
+      let detail = text;
+      try {
+        detail = (JSON.parse(text) as { error?: string }).error ?? text;
+      } catch {
+        // Not JSON — a proxy or the wrong port. The raw body is more use than a parse error.
+      }
+      throw new Error(`room API ${method} ${route} failed (HTTP ${response.status}): ${detail}`);
+    }
+    return text === '' ? {} : (JSON.parse(text) as unknown);
+  };
+
+  return {
+    check: async () => {
+      // Checked before any request so a missing token reads as the configuration mistake it is.
+      // Left to the request it would surface as a transport failure, sending people to look at the
+      // network instead of at their env — and forgetting the token is the likeliest slip here.
+      if (!roomApiToken()) {
+        throw new Error(
+          `SOGS_ROOM_API is set to ${roomApiBase()} but SOGS_ROOM_API_TOKEN is empty. Set it to ` +
+            `the same value as the sogs container's SOGS_ROOM_API_TOKEN`
+        );
+      }
+      await call('GET', '/rooms');
+    },
+    create: async (token, name) => void (await call('POST', '/rooms', { name, token })),
+    describe: `room API at ${roomApiBase()}`,
+    gc: async olderThanSeconds => {
+      const result = (await call('POST', '/rooms/gc', { older_than: olderThanSeconds })) as {
+        kept?: string[];
+        removed?: string[];
+      };
+      return (
+        `gc: removed ${result.removed?.length ?? 0} room(s), left ` +
+        `${result.kept?.length ?? 0} inside the ${olderThanSeconds}s TTL.`
+      );
+    },
+    remove: async token => void (await call('DELETE', `/rooms/${encodeURIComponent(token)}`)),
+  };
 }
 
 let allocated: CommunityRoom[] = [];
@@ -106,28 +192,17 @@ export function perTestRoomsEnabled(): boolean {
  * Decide once, at the start of a run, whether per-test rooms are usable, and record it for the
  * workers.
  *
- * The check is a `list` through whichever transport is configured, not a reachability probe of SOGS
- * itself: what matters is whether we can *create* rooms, and a healthy SOGS API says nothing about
- * that. Over the CLI it needs docker, a running container and a working `room.py`; over HTTP it needs
- * the room API running with a matching token. That distinction is exactly the CI case — SOGS reachable
- * over the network, its container on another host.
+ * The check asks the transport, not SOGS: what matters is whether rooms can be *created*, and a
+ * healthy SOGS API says nothing about that. Over the CLI it needs docker, a running container and a
+ * working `room.py`; over HTTP it needs the room API up with a matching token. That distinction is
+ * exactly the CI case — SOGS reachable over the network, its container on another host.
  *
- * Either being unusable falls back to the shared rooms rather than failing the run, since that
+ * An unusable transport falls back to the shared rooms rather than failing the run, since that
  * configuration still tests everything — it just can't isolate concurrent runs. The warning is
  * deliberately loud: sharing rooms silently while reporting green is the failure mode this feature
  * exists to remove, so it should be obvious in the log which mode a run used.
  */
 export async function probePerTestRooms(): Promise<boolean> {
-  const fallBack = (why: string): boolean => {
-    process.env[ENABLED_FLAG] = '0';
-    console.warn(
-      `\n⚠ Per-test community rooms are OFF — ${why}\n` +
-        `  Community tests will share the fixed rooms in run/constants/community.ts, so a run ` +
-        `against the same SOGS elsewhere can interfere with this one.\n`
-    );
-    return false;
-  };
-
   if (!process.env.COMMUNITY_LINK) {
     // Pointed at the shared remote communities: nothing can be created, and that is a choice rather
     // than a misconfiguration, so it warrants no warning.
@@ -135,51 +210,22 @@ export async function probePerTestRooms(): Promise<boolean> {
     return false;
   }
 
-  // The HTTP API wins when configured: it is the deliberate choice of the two, only set where the
-  // CLI cannot work.
-  if (useRoomApi()) {
-    // Checked before the request so a missing token reads as the configuration mistake it is. Left
-    // to the request below it would surface as "the room API is unusable", which sends people looking
-    // at the network instead of at their env — and forgetting the token is the likeliest slip here.
-    if (!roomApiToken()) {
-      return fallBack(
-        `SOGS_ROOM_API is set to ${roomApiBase()} but SOGS_ROOM_API_TOKEN is empty. Set it to the ` +
-          `same value as the sogs container's SOGS_ROOM_API_TOKEN`
-      );
-    }
-
-    try {
-      await callRoomApi('GET', '/rooms');
-    } catch (e) {
-      return fallBack(
-        `the room API at ${roomApiBase()} is unusable: ${
-          e instanceof Error ? e.message.split('\n')[0] : String(e)
-        }`
-      );
-    }
-    process.env[ENABLED_FLAG] = '1';
-    console.log(`Per-test community rooms enabled (via room API at ${roomApiBase()})`);
-    return true;
-  }
-
-  const cli = roomCliPath();
-  if (!existsSync(cli)) {
-    return fallBack(
-      `no room CLI at ${cli} and SOGS_ROOM_API is unset. Point SOGS_ROOM_CLI at your ` +
-        `Sesh-Net-Docker checkout's sogs/room.sh, or set SOGS_ROOM_API + SOGS_ROOM_API_TOKEN`
-    );
-  }
-
   try {
-    await runRoomCli(['list']);
+    await roomTransport().check();
   } catch (e) {
-    return fallBack(
-      `the room CLI at ${cli} failed: ${e instanceof Error ? e.message.split('\n')[0] : String(e)}`
+    process.env[ENABLED_FLAG] = '0';
+    console.warn(
+      `\n⚠ Per-test community rooms are OFF — ${
+        e instanceof Error ? e.message.split('\n')[0] : String(e)
+      }\n` +
+        `  Community tests will share the fixed rooms in run/constants/community.ts, so a run ` +
+        `against the same SOGS elsewhere can interfere with this one.\n`
     );
+    return false;
   }
 
   process.env[ENABLED_FLAG] = '1';
-  console.log(`Per-test community rooms enabled (via room CLI at ${cli})`);
+  console.log(`Per-test community rooms enabled (via ${roomTransport().describe})`);
   return true;
 }
 
@@ -195,11 +241,6 @@ function nextToken(): string {
   const worker = process.env.TEST_PARALLEL_INDEX ?? '0';
   allocationCounter += 1;
   return `qa-${runId}-w${worker}-${allocationCounter}`;
-}
-
-async function runRoomCli(args: Array<string>): Promise<string> {
-  const { stdout } = await execFileAsync(roomCliPath(), args, { timeout: 60_000 });
-  return stdout.trim();
 }
 
 /**
@@ -222,11 +263,7 @@ export async function allocateCommunityRooms(count: number): Promise<Array<Commu
   for (let i = 0; i < count; i++) {
     const token = nextToken();
     const name = `QA ${token}`;
-    if (useRoomApi()) {
-      await callRoomApi('POST', '/rooms', { name, token });
-    } else {
-      await runRoomCli(['create', token, '--name', name]);
-    }
+    await roomTransport().create(token, name);
     rooms.push({ link: linkForToken(token), name, roomName: token });
   }
   return rooms;
@@ -241,11 +278,7 @@ export async function releaseCommunityRooms(): Promise<void> {
   allocated = [];
   for (const room of toRelease) {
     try {
-      if (useRoomApi()) {
-        await callRoomApi('DELETE', `/rooms/${encodeURIComponent(room.roomName)}`);
-      } else {
-        await runRoomCli(['delete', room.roomName]);
-      }
+      await roomTransport().remove(room.roomName);
     } catch (e) {
       console.warn(
         `Failed to delete community room "${room.roomName}" (gc will collect it): ${
@@ -270,19 +303,7 @@ export async function gcCommunityRooms(olderThanSeconds: number = 3_600): Promis
     return;
   }
   try {
-    if (useRoomApi()) {
-      const result = (await callRoomApi('POST', '/rooms/gc', {
-        older_than: olderThanSeconds,
-      })) as { kept?: string[]; removed?: string[] };
-      console.log(
-        `gc: removed ${result.removed?.length ?? 0} room(s), left ${
-          result.kept?.length ?? 0
-        } inside the ${olderThanSeconds}s TTL.`
-      );
-    } else {
-      const output = await runRoomCli(['gc', '--older-than', String(olderThanSeconds)]);
-      console.log(output.split('\n')[0]);
-    }
+    console.log(await roomTransport().gc(olderThanSeconds));
   } catch (e) {
     console.warn(
       `Community room gc failed (continuing): ${e instanceof Error ? e.message : String(e)}`

--- a/run/test/utils/community_rooms.ts
+++ b/run/test/utils/community_rooms.ts
@@ -1,9 +1,10 @@
-import { execFile } from 'child_process';
-import { existsSync } from 'fs';
-import path from 'path';
-import { promisify } from 'util';
-
-const execFileAsync = promisify(execFile);
+import {
+  describeFailure,
+  identityFromRecoveryPhrase,
+  SogsIdentity,
+  sogsRequest,
+} from './sogs_auth';
+import { buildSeedMessage } from './sogs_seed_message';
 
 export type CommunityRoom = {
   link: string;
@@ -18,157 +19,157 @@ export type CommunityRoom = {
  * a laptop, or two CI jobs — joined, posted, pinned and banned in the same place. Each test now gets
  * rooms of its own, which also means a test is free to leave a room in whatever state it likes.
  *
- * Only possible against a local SOGS: creating a room has no HTTP endpoint in PySOGS, so it goes
- * through `room.sh` (which shells into the container). When COMMUNITY_LINK is unset the suite is
- * pointed at the shared remote communities and there is nothing we can create, so allocation is
- * disabled and the static list in constants/community.ts is used exactly as before.
+ * Only possible against a local SOGS, since it means creating and deleting rooms on it: when
+ * COMMUNITY_LINK is unset the suite is pointed at the shared remote communities, allocation is
+ * disabled, and the static list in constants/community.ts is used exactly as before.
+ *
+ * Everything goes through SOGS's own HTTP API, authenticated as a global admin (SOGS_ADMIN_SEED, the
+ * account the community moderation tests already use). Nothing here needs shell or Docker access to
+ * the machine running SOGS, which is what lets CI — a different host from the devnet — use it.
  *
  * State here is module-level, which is per-worker (Playwright workers are separate processes) and
  * therefore safe: tests within a worker run one at a time.
  */
 
 /**
- * How rooms are managed. Two implementations, differing only in how they reach SOGS — the room
- * semantics, including the `qa-` prefix rule and the gc TTL, are enforced on the server either way.
+ * Marks a room as this suite's to delete.
  *
- * `gc` returns its own one-line summary rather than counts: the CLI already prints one, and parsing it
- * back into numbers just to reformat it would be a brittle way to reach the same log line.
+ * SOGS has no notion of a temporary room, so the rule is ours and is enforced here, on every path
+ * that deletes: a room whose token doesn't start with this is not something a test created, and a bug
+ * that pointed a delete at one would take out a long-lived room. Asserting it in one place is cheap
+ * next to that.
  */
-type RoomTransport = {
-  create(token: string, name: string): Promise<void>;
-  /** Shown in the "per-test rooms enabled" line. */
-  readonly describe: string;
-  gc(olderThanSeconds: number): Promise<string>;
-  /** Rejects when rooms can't be managed. Used as the availability check by `probePerTestRooms`. */
-  check(): Promise<void>;
-  remove(token: string): Promise<void>;
+const DISPOSABLE_PREFIX = 'qa-';
+
+type SogsTarget = {
+  admin: SogsIdentity;
+  base: string;
+  serverPubkey: Uint8Array;
 };
 
-// Default assumes Sesh-Net-Docker is checked out alongside this repo; override in .env when it isn't.
-const roomCliPath = () =>
-  process.env.SOGS_ROOM_CLI ?? path.resolve(process.cwd(), '../Sesh-Net-Docker/sogs/room.sh');
-
-const roomApiBase = () => (process.env.SOGS_ROOM_API ?? '').trim().replace(/\/$/, '');
-const roomApiToken = () => (process.env.SOGS_ROOM_API_TOKEN ?? '').trim();
+let target: SogsTarget | undefined;
 
 /**
- * Chosen from the environment once per process, then reused.
+ * Where to reach SOGS and who to be, derived once per process from the environment.
  *
- * Not chosen in `probePerTestRooms` and stored for everyone: workers are separate processes and
- * inherit the env, not module state, so each derives this for itself. Deriving it once per process
- * rather than per call is what stops four call sites disagreeing if the environment changes mid-run.
+ * Both halves come from configuration the suite already has: the origin and the server's public key
+ * out of COMMUNITY_LINK (the same link the tests hand to the app), and the admin account out of
+ * SOGS_ADMIN_SEED. Nothing further needs setting to turn per-test rooms on.
+ *
+ * Not derived once in `probePerTestRooms` and shared: workers are separate processes and inherit the
+ * environment, not module state, so each derives this for itself.
  */
-let transport: RoomTransport | undefined;
+function sogsTarget(): SogsTarget {
+  if (target) {
+    return target;
+  }
 
-function roomTransport(): RoomTransport {
-  transport ??= roomApiBase() === '' ? cliTransport() : apiTransport();
-  return transport;
+  const link = process.env.COMMUNITY_LINK;
+  if (!link) {
+    throw new Error('COMMUNITY_LINK is unset, so there is no SOGS to create rooms on');
+  }
+  const recoveryPhrase = process.env.SOGS_ADMIN_SEED;
+  if (!recoveryPhrase) {
+    throw new Error(
+      'SOGS_ADMIN_SEED is unset. Creating and deleting rooms requires a global admin on the ' +
+        "SOGS; set it to the recovery phrase of one (locally, the account in the sogs container's " +
+        'SOGS_ADMIN_SESSION_IDS — see Sesh-Net-Docker/sogs/docker-compose.yml)'
+    );
+  }
+
+  const url = new URL(link);
+  const publicKey = url.searchParams.get('public_key');
+  if (!publicKey || !/^[0-9a-fA-F]{64}$/.test(publicKey)) {
+    throw new Error(`COMMUNITY_LINK has no valid public_key parameter: ${link}`);
+  }
+
+  target = {
+    admin: identityFromRecoveryPhrase(recoveryPhrase),
+    base: `${url.protocol}//${url.host}`,
+    serverPubkey: new Uint8Array(Buffer.from(publicKey, 'hex')),
+  };
+  return target;
+}
+
+/** A signed request to SOGS as the admin account. */
+async function asAdmin(method: 'DELETE' | 'GET' | 'POST', path: string, body?: unknown) {
+  const { admin, base, serverPubkey } = sogsTarget();
+  return sogsRequest({ base, body, identity: admin, method, path, serverPubkey });
+}
+
+/** Rooms on the server, with the creation time gc needs. Requires the admin to be a global admin. */
+type RoomListing = { created: number; token: string };
+
+async function listRooms(): Promise<Array<RoomListing>> {
+  const response = await asAdmin('GET', '/rooms');
+  if (response.status === 401) {
+    throw new Error(
+      `SOGS rejected our authentication (${describeFailure(response)}). This is a signing or key ` +
+        `problem rather than a permissions one — check SOGS_ADMIN_SEED is a valid recovery phrase`
+    );
+  }
+  if (response.status === 403) {
+    throw new Error(
+      `the SOGS_ADMIN_SEED account is not a global admin on ${sogsTarget().base}, so it cannot ` +
+        `create or delete rooms (${describeFailure(response)})`
+    );
+  }
+  if (response.status !== 200) {
+    throw new Error(`could not list rooms on ${sogsTarget().base} (${describeFailure(response)})`);
+  }
+  return response.body as Array<RoomListing>;
 }
 
 /**
- * Shells into the container via Sesh-Net-Docker's `room.sh`. The default when nothing else is
- * configured, because it needs no token and no exposed port — with that repo checked out alongside
- * this one it works with nothing set but COMMUNITY_LINK.
+ * Create a room and post the first message to it.
+ *
+ * The message is not optional: `joinCommunity` waits for one, so a client joining an empty room hangs
+ * rather than failing (see sogs_seed_message.ts). SOGS creates rooms empty and has no opinion about
+ * it, so seeding belongs to whoever creates the room — us.
  */
-function cliTransport(): RoomTransport {
-  const run = async (args: Array<string>): Promise<string> => {
-    const { stdout } = await execFileAsync(roomCliPath(), args, { timeout: 60_000 });
-    return stdout.trim();
-  };
+async function createRoom(token: string, name: string): Promise<void> {
+  const created = await asAdmin('POST', '/rooms', { description: null, name, token });
+  if (created.status === 404 || created.status === 405) {
+    throw new Error(
+      `this SOGS has no room creation endpoint (${describeFailure(created)}). POST /rooms and ` +
+        `DELETE /room/<token> were added in session-pysogs; the server needs to be new enough to ` +
+        `have them`
+    );
+  }
+  if (created.status !== 201) {
+    throw new Error(`could not create room "${token}" (${describeFailure(created)})`);
+  }
 
-  return {
-    check: async () => {
-      const cli = roomCliPath();
-      if (!existsSync(cli)) {
-        throw new Error(
-          `no room CLI at ${cli} and SOGS_ROOM_API is unset. Point SOGS_ROOM_CLI at your ` +
-            `Sesh-Net-Docker checkout's sogs/room.sh, or set SOGS_ROOM_API + SOGS_ROOM_API_TOKEN`
-        );
-      }
-      await run(['list']);
-    },
-    create: async (token, name) => void (await run(['create', token, '--name', name])),
-    describe: `room CLI at ${roomCliPath()}`,
-    gc: async olderThanSeconds =>
-      (await run(['gc', '--older-than', String(olderThanSeconds)])).split('\n')[0],
-    remove: async token => void (await run(['delete', token])),
-  };
+  const { identity, request } = buildSeedMessage(token, name, sogsTarget().serverPubkey);
+  const { base, serverPubkey } = sogsTarget();
+  const seeded = await sogsRequest({
+    base,
+    body: request,
+    identity,
+    method: 'POST',
+    path: `/room/${token}/message`,
+    serverPubkey,
+  });
+  if (seeded.status !== 201) {
+    throw new Error(
+      `created room "${token}" but could not post its first message ` +
+        `(${describeFailure(seeded)}); a client joining it would hang, so treating this as fatal`
+    );
+  }
 }
 
-/**
- * Talks to `sogs/room_api.py` over HTTP. For hosts that can reach the SOGS container but can't
- * `docker exec` into it — a CI runner driving a devnet that lives on another host. Takes precedence
- * when SOGS_ROOM_API is set, since it is the deliberate choice of the two.
- */
-function apiTransport(): RoomTransport {
-  const call = async (
-    method: 'DELETE' | 'GET' | 'POST',
-    route: string,
-    body?: unknown
-  ): Promise<unknown> => {
-    const token = roomApiToken();
-    if (!token) {
-      // `check` reports this properly; reaching it here would mean the token was cleared mid-run.
-      throw new Error('SOGS_ROOM_API_TOKEN is empty');
-    }
-
-    const response = await fetch(`${roomApiBase()}${route}`, {
-      body: body === undefined ? undefined : JSON.stringify(body),
-      headers: {
-        Authorization: `Bearer ${token}`,
-        ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
-      },
-      method,
-      // Create is the slowest operation and it seeds a message, so it isn't instant — but it has
-      // measured well under 2s, so this is a generous ceiling rather than an expected duration.
-      signal: AbortSignal.timeout(30_000),
-    });
-
-    const text = await response.text();
-    if (!response.ok) {
-      // The API answers refusals as JSON `{error}`; surface that rather than a bare status.
-      let detail = text;
-      try {
-        detail = (JSON.parse(text) as { error?: string }).error ?? text;
-      } catch {
-        // Not JSON — a proxy or the wrong port. The raw body is more use than a parse error.
-      }
-      throw new Error(`room API ${method} ${route} failed (HTTP ${response.status}): ${detail}`);
-    }
-    return text === '' ? {} : (JSON.parse(text) as unknown);
-  };
-
-  return {
-    check: async () => {
-      // Checked before any request so a missing token reads as the configuration mistake it is.
-      // Left to the request it would surface as a transport failure, sending people to look at the
-      // network instead of at their env — and forgetting the token is the likeliest slip here.
-      if (!roomApiToken()) {
-        throw new Error(
-          `SOGS_ROOM_API is set to ${roomApiBase()} but SOGS_ROOM_API_TOKEN is empty. Set it to ` +
-            `the same value as the sogs container's SOGS_ROOM_API_TOKEN`
-        );
-      }
-      // `GET /rooms` rather than the API's `/healthz`, deliberately: healthz is unauthenticated, so it
-      // proves only that something is listening. Listing rooms proves reachable *and* token accepted
-      // *and* database queryable — otherwise a wrong token passes the probe and fails on the first
-      // allocation instead. healthz stays useful for "is it up at all" without holding the token.
-      await call('GET', '/rooms');
-    },
-    create: async (token, name) => void (await call('POST', '/rooms', { name, token })),
-    describe: `room API at ${roomApiBase()}`,
-    gc: async olderThanSeconds => {
-      const result = (await call('POST', '/rooms/gc', { older_than: olderThanSeconds })) as {
-        kept?: string[];
-        removed?: string[];
-      };
-      return (
-        `gc: removed ${result.removed?.length ?? 0} room(s), left ` +
-        `${result.kept?.length ?? 0} inside the ${olderThanSeconds}s TTL.`
-      );
-    },
-    remove: async token => void (await call('DELETE', `/rooms/${encodeURIComponent(token)}`)),
-  };
+/** Delete a room. A room that has already gone is the normal outcome of a retried teardown. */
+async function deleteRoom(token: string): Promise<void> {
+  if (!token.startsWith(DISPOSABLE_PREFIX)) {
+    throw new Error(
+      `refusing to delete room "${token}": only rooms prefixed "${DISPOSABLE_PREFIX}" are this ` +
+        `suite's to remove`
+    );
+  }
+  const response = await asAdmin('DELETE', `/room/${token}`);
+  if (response.status !== 200 && response.status !== 404) {
+    throw new Error(`could not delete room "${token}" (${describeFailure(response)})`);
+  }
 }
 
 let allocated: CommunityRoom[] = [];
@@ -203,12 +204,12 @@ export function perTestRoomsEnabled(): boolean {
  * Decide once, at the start of a run, whether per-test rooms are usable, and record it for the
  * workers.
  *
- * The check asks the transport, not SOGS: what matters is whether rooms can be *created*, and a
- * healthy SOGS API says nothing about that. Over the CLI it needs docker, a running container and a
- * working `room.py`; over HTTP it needs the room API up with a matching token. That distinction is
- * exactly the CI case — SOGS reachable over the network, its container on another host.
+ * Listing rooms is the check because it exercises everything creating one needs — SOGS reachable, our
+ * request signing accepted, and the account a global admin — and it is the one admin-only read that
+ * changes nothing. A cheaper check that only proved SOGS was up would pass here and fail on the first
+ * allocation instead, which is a much worse place to find out.
  *
- * An unusable transport falls back to the shared rooms rather than failing the run, since that
+ * An unusable server falls back to the shared rooms rather than failing the run, since that
  * configuration still tests everything — it just can't isolate concurrent runs. The warning is
  * deliberately loud: sharing rooms silently while reporting green is the failure mode this feature
  * exists to remove, so it should be obvious in the log which mode a run used.
@@ -222,7 +223,7 @@ export async function probePerTestRooms(): Promise<boolean> {
   }
 
   try {
-    await roomTransport().check();
+    await listRooms();
   } catch (e) {
     process.env[ENABLED_FLAG] = '0';
     console.warn(
@@ -236,7 +237,7 @@ export async function probePerTestRooms(): Promise<boolean> {
   }
 
   process.env[ENABLED_FLAG] = '1';
-  console.log(`Per-test community rooms enabled (via ${roomTransport().describe})`);
+  console.log(`Per-test community rooms enabled (on ${sogsTarget().base})`);
   return true;
 }
 
@@ -244,20 +245,18 @@ export async function probePerTestRooms(): Promise<boolean> {
  * Token for a room, unique across concurrent runs and workers.
  *
  * QA_RUN_ID is stamped once per run in global-setup; without it two runs starting together could
- * pick the same token and delete each other's rooms. The `qa-` prefix is what marks a room
- * disposable — room.py refuses to delete anything without it.
+ * pick the same token and delete each other's rooms.
  */
 function nextToken(): string {
   const runId = process.env.QA_RUN_ID ?? 'local';
   const worker = process.env.TEST_PARALLEL_INDEX ?? '0';
   allocationCounter += 1;
-  return `qa-${runId}-w${worker}-${allocationCounter}`;
+  return `${DISPOSABLE_PREFIX}${runId}-w${worker}-${allocationCounter}`;
 }
 
 /**
- * The link room.py prints is built from the server's own URL_BASE, which is localhost — unreachable
- * from a simulator. The host that does work is already in COMMUNITY_LINK, so reuse its origin and
- * public_key and swap in the new token, mirroring buildLocalCommunities.
+ * The link a client joins the room with. Built from COMMUNITY_LINK's origin and public_key rather
+ * than the server's own idea of its address, which is localhost and unreachable from a simulator.
  */
 function linkForToken(token: string): string {
   const base = new URL(process.env.COMMUNITY_LINK as string);
@@ -274,10 +273,12 @@ export async function allocateCommunityRooms(count: number): Promise<Array<Commu
   for (let i = 0; i < count; i++) {
     const token = nextToken();
     const name = `QA ${token}`;
-    await roomTransport().create(token, name);
+    await createRoom(token, name);
     rooms.push({ link: linkForToken(token), name, roomName: token });
   }
-  return rooms;
+  // A copy: `rooms` *is* the module's record of what to clean up, so handing it out directly would let
+  // a caller drop rooms from it and leak them.
+  return [...rooms];
 }
 
 /**
@@ -289,7 +290,7 @@ export async function releaseCommunityRooms(): Promise<void> {
   allocated = [];
   for (const room of toRelease) {
     try {
-      await roomTransport().remove(room.roomName);
+      await deleteRoom(room.roomName);
     } catch (e) {
       console.warn(
         `Failed to delete community room "${room.roomName}" (gc will collect it): ${
@@ -300,21 +301,37 @@ export async function releaseCommunityRooms(): Promise<void> {
   }
 }
 
+/** A copy, for the same reason `allocateCommunityRooms` returns one. */
 export function getAllocatedRooms(): Array<CommunityRoom> {
-  return allocated;
+  return [...allocated];
 }
 
 /**
- * Remove rooms orphaned by runs that were killed before teardown. The TTL is what stops this
- * deleting a room out from under a test that is still running, so it must comfortably exceed the
- * longest single test.
+ * Remove rooms orphaned by runs that were killed before teardown.
+ *
+ * Which rooms those are is decided here rather than by the server: SOGS reports every room's token
+ * and creation time, and what counts as disposable is this suite's rule, not something SOGS knows
+ * about. The TTL is what stops this deleting a room out from under a test that is still running — a
+ * concurrent run's rooms are indistinguishable from an abandoned one's — so it must comfortably
+ * exceed the longest single test.
  */
 export async function gcCommunityRooms(olderThanSeconds: number = 3_600): Promise<void> {
   if (!perTestRoomsEnabled()) {
     return;
   }
+
   try {
-    console.log(await roomTransport().gc(olderThanSeconds));
+    const cutoff = Date.now() / 1_000 - olderThanSeconds;
+    const disposable = (await listRooms()).filter(room => room.token.startsWith(DISPOSABLE_PREFIX));
+    const stale = disposable.filter(room => room.created <= cutoff);
+
+    for (const room of stale) {
+      await deleteRoom(room.token);
+    }
+    console.log(
+      `gc: removed ${stale.length} room(s), left ${disposable.length - stale.length} inside the ` +
+        `${olderThanSeconds}s TTL.`
+    );
   } catch (e) {
     console.warn(
       `Community room gc failed (continuing): ${e instanceof Error ? e.message : String(e)}`

--- a/run/test/utils/community_rooms.ts
+++ b/run/test/utils/community_rooms.ts
@@ -1,0 +1,291 @@
+import { execFile } from 'child_process';
+import { existsSync } from 'fs';
+import path from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export type CommunityRoom = {
+  link: string;
+  name: string;
+  roomName: string;
+};
+
+/**
+ * Per-test community rooms.
+ *
+ * The community specs used to share a fixed set of rooms, so two runs against the same SOGS — CI and
+ * a laptop, or two CI jobs — joined, posted, pinned and banned in the same place. Each test now gets
+ * rooms of its own, which also means a test is free to leave a room in whatever state it likes.
+ *
+ * Only possible against a local SOGS: creating a room has no HTTP endpoint in PySOGS, so it goes
+ * through `room.sh` (which shells into the container). When COMMUNITY_LINK is unset the suite is
+ * pointed at the shared remote communities and there is nothing we can create, so allocation is
+ * disabled and the static list in constants/community.ts is used exactly as before.
+ *
+ * State here is module-level, which is per-worker (Playwright workers are separate processes) and
+ * therefore safe: tests within a worker run one at a time.
+ */
+
+// Default assumes Sesh-Net-Docker is checked out alongside this repo; override in .env when it isn't.
+const roomCliPath = () =>
+  process.env.SOGS_ROOM_CLI ?? path.resolve(process.cwd(), '../Sesh-Net-Docker/sogs/room.sh');
+
+/**
+ * The HTTP transport, used when SOGS_ROOM_API is set.
+ *
+ * `room.sh` needs a local Docker daemon, which the case this exists for doesn't have: a CI runner
+ * driving a devnet on another host. Sesh-Net-Docker's sogs container can expose the same operations
+ * on a port instead (`sogs/room_api.py`), so the choice here is purely about how we reach it — the
+ * room semantics, including the `qa-` prefix rule, are enforced on the server either way.
+ */
+const roomApiBase = () => (process.env.SOGS_ROOM_API ?? '').trim().replace(/\/$/, '');
+const useRoomApi = () => roomApiBase() !== '';
+const roomApiToken = () => (process.env.SOGS_ROOM_API_TOKEN ?? '').trim();
+
+async function callRoomApi(
+  method: 'DELETE' | 'GET' | 'POST',
+  route: string,
+  body?: unknown
+): Promise<unknown> {
+  const token = roomApiToken();
+  if (!token) {
+    // The probe checks for this up front and reports it properly; reaching it here would mean the
+    // token was cleared mid-run.
+    throw new Error('SOGS_ROOM_API_TOKEN is empty');
+  }
+
+  const response = await fetch(`${roomApiBase()}${route}`, {
+    body: body === undefined ? undefined : JSON.stringify(body),
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+    },
+    method,
+    signal: AbortSignal.timeout(60_000),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    // The API answers refusals as JSON `{error}`; surface that rather than a bare status.
+    let detail = text;
+    try {
+      detail = (JSON.parse(text) as { error?: string }).error ?? text;
+    } catch {
+      // Not JSON — a proxy or the wrong port. The raw body is more use than a parse error.
+    }
+    throw new Error(`room API ${method} ${route} failed (HTTP ${response.status}): ${detail}`);
+  }
+  return text === '' ? {} : (JSON.parse(text) as unknown);
+}
+
+let allocated: CommunityRoom[] = [];
+let allocationCounter = 0;
+
+/**
+ * Env var carrying the decision from global-setup to the workers, which inherit this process's env.
+ */
+const ENABLED_FLAG = 'PER_TEST_COMMUNITY_ROOMS';
+
+/**
+ * Whether this run allocates its own rooms.
+ *
+ * A cheap read of a decision made once by `probePerTestRooms` — deliberately not a check. This is
+ * called on every `communities` property access, so it must not touch the filesystem or the network,
+ * and every caller must agree: a test that allocated rooms and a `communities` lookup that decided
+ * otherwise would read a shared room while believing it had its own.
+ *
+ * Defaults to off when the probe hasn't run, so anything importing this outside a test run gets the
+ * static list rather than attempting allocation.
+ */
+export function perTestRoomsEnabled(): boolean {
+  return process.env[ENABLED_FLAG] === '1';
+}
+
+/**
+ * Decide once, at the start of a run, whether per-test rooms are usable, and record it for the
+ * workers.
+ *
+ * The check is a `list` through whichever transport is configured, not a reachability probe of SOGS
+ * itself: what matters is whether we can *create* rooms, and a healthy SOGS API says nothing about
+ * that. Over the CLI it needs docker, a running container and a working `room.py`; over HTTP it needs
+ * the room API running with a matching token. That distinction is exactly the CI case — SOGS reachable
+ * over the network, its container on another host.
+ *
+ * Either being unusable falls back to the shared rooms rather than failing the run, since that
+ * configuration still tests everything — it just can't isolate concurrent runs. The warning is
+ * deliberately loud: sharing rooms silently while reporting green is the failure mode this feature
+ * exists to remove, so it should be obvious in the log which mode a run used.
+ */
+export async function probePerTestRooms(): Promise<boolean> {
+  const fallBack = (why: string): boolean => {
+    process.env[ENABLED_FLAG] = '0';
+    console.warn(
+      `\n⚠ Per-test community rooms are OFF — ${why}\n` +
+        `  Community tests will share the fixed rooms in run/constants/community.ts, so a run ` +
+        `against the same SOGS elsewhere can interfere with this one.\n`
+    );
+    return false;
+  };
+
+  if (!process.env.COMMUNITY_LINK) {
+    // Pointed at the shared remote communities: nothing can be created, and that is a choice rather
+    // than a misconfiguration, so it warrants no warning.
+    process.env[ENABLED_FLAG] = '0';
+    return false;
+  }
+
+  // The HTTP API wins when configured: it is the deliberate choice of the two, only set where the
+  // CLI cannot work.
+  if (useRoomApi()) {
+    // Checked before the request so a missing token reads as the configuration mistake it is. Left
+    // to the request below it would surface as "the room API is unusable", which sends people looking
+    // at the network instead of at their env — and forgetting the token is the likeliest slip here.
+    if (!roomApiToken()) {
+      return fallBack(
+        `SOGS_ROOM_API is set to ${roomApiBase()} but SOGS_ROOM_API_TOKEN is empty. Set it to the ` +
+          `same value as the sogs container's SOGS_ROOM_API_TOKEN`
+      );
+    }
+
+    try {
+      await callRoomApi('GET', '/rooms');
+    } catch (e) {
+      return fallBack(
+        `the room API at ${roomApiBase()} is unusable: ${
+          e instanceof Error ? e.message.split('\n')[0] : String(e)
+        }`
+      );
+    }
+    process.env[ENABLED_FLAG] = '1';
+    console.log(`Per-test community rooms enabled (via room API at ${roomApiBase()})`);
+    return true;
+  }
+
+  const cli = roomCliPath();
+  if (!existsSync(cli)) {
+    return fallBack(
+      `no room CLI at ${cli} and SOGS_ROOM_API is unset. Point SOGS_ROOM_CLI at your ` +
+        `Sesh-Net-Docker checkout's sogs/room.sh, or set SOGS_ROOM_API + SOGS_ROOM_API_TOKEN`
+    );
+  }
+
+  try {
+    await runRoomCli(['list']);
+  } catch (e) {
+    return fallBack(
+      `the room CLI at ${cli} failed: ${e instanceof Error ? e.message.split('\n')[0] : String(e)}`
+    );
+  }
+
+  process.env[ENABLED_FLAG] = '1';
+  console.log(`Per-test community rooms enabled (via room CLI at ${cli})`);
+  return true;
+}
+
+/**
+ * Token for a room, unique across concurrent runs and workers.
+ *
+ * QA_RUN_ID is stamped once per run in global-setup; without it two runs starting together could
+ * pick the same token and delete each other's rooms. The `qa-` prefix is what marks a room
+ * disposable — room.py refuses to delete anything without it.
+ */
+function nextToken(): string {
+  const runId = process.env.QA_RUN_ID ?? 'local';
+  const worker = process.env.TEST_PARALLEL_INDEX ?? '0';
+  allocationCounter += 1;
+  return `qa-${runId}-w${worker}-${allocationCounter}`;
+}
+
+async function runRoomCli(args: Array<string>): Promise<string> {
+  const { stdout } = await execFileAsync(roomCliPath(), args, { timeout: 60_000 });
+  return stdout.trim();
+}
+
+/**
+ * The link room.py prints is built from the server's own URL_BASE, which is localhost — unreachable
+ * from a simulator. The host that does work is already in COMMUNITY_LINK, so reuse its origin and
+ * public_key and swap in the new token, mirroring buildLocalCommunities.
+ */
+function linkForToken(token: string): string {
+  const base = new URL(process.env.COMMUNITY_LINK as string);
+  return `${base.protocol}//${base.host}/${token}${base.search}`;
+}
+
+export async function allocateCommunityRooms(count: number): Promise<Array<CommunityRoom>> {
+  // Published before the loop, not after, so `allocated` tracks partial progress: a create that
+  // fails on room 3 of 6 has still created two, and releasing what exists is only possible if
+  // something recorded them. Otherwise they linger until the gc sweep's TTL expires.
+  const rooms: Array<CommunityRoom> = [];
+  allocated = rooms;
+
+  for (let i = 0; i < count; i++) {
+    const token = nextToken();
+    const name = `QA ${token}`;
+    if (useRoomApi()) {
+      await callRoomApi('POST', '/rooms', { name, token });
+    } else {
+      await runRoomCli(['create', token, '--name', name]);
+    }
+    rooms.push({ link: linkForToken(token), name, roomName: token });
+  }
+  return rooms;
+}
+
+/**
+ * Best-effort: a room left behind is picked up by the gc sweep, so a failure to delete should never
+ * turn a passing test red.
+ */
+export async function releaseCommunityRooms(): Promise<void> {
+  const toRelease = allocated;
+  allocated = [];
+  for (const room of toRelease) {
+    try {
+      if (useRoomApi()) {
+        await callRoomApi('DELETE', `/rooms/${encodeURIComponent(room.roomName)}`);
+      } else {
+        await runRoomCli(['delete', room.roomName]);
+      }
+    } catch (e) {
+      console.warn(
+        `Failed to delete community room "${room.roomName}" (gc will collect it): ${
+          e instanceof Error ? e.message : String(e)
+        }`
+      );
+    }
+  }
+}
+
+export function getAllocatedRooms(): Array<CommunityRoom> {
+  return allocated;
+}
+
+/**
+ * Remove rooms orphaned by runs that were killed before teardown. The TTL is what stops this
+ * deleting a room out from under a test that is still running, so it must comfortably exceed the
+ * longest single test.
+ */
+export async function gcCommunityRooms(olderThanSeconds: number = 3_600): Promise<void> {
+  if (!perTestRoomsEnabled()) {
+    return;
+  }
+  try {
+    if (useRoomApi()) {
+      const result = (await callRoomApi('POST', '/rooms/gc', {
+        older_than: olderThanSeconds,
+      })) as { kept?: string[]; removed?: string[] };
+      console.log(
+        `gc: removed ${result.removed?.length ?? 0} room(s), left ${
+          result.kept?.length ?? 0
+        } inside the ${olderThanSeconds}s TTL.`
+      );
+    } else {
+      const output = await runRoomCli(['gc', '--older-than', String(olderThanSeconds)]);
+      console.log(output.split('\n')[0]);
+    }
+  } catch (e) {
+    console.warn(
+      `Community room gc failed (continuing): ${e instanceof Error ? e.message : String(e)}`
+    );
+  }
+}

--- a/run/test/utils/mock_pro.ts
+++ b/run/test/utils/mock_pro.ts
@@ -89,7 +89,7 @@ function getWordlist(): string[] {
 }
 
 // Decodes a 13-word recovery phrase to a 16-byte seed hex string. */
-function mnemonicToSeedHex(mnemonic: string): string {
+export function mnemonicToSeedHex(mnemonic: string): string {
   const wordlist = getWordlist();
   const n = wordlist.length; // 1626
 
@@ -145,7 +145,7 @@ function mnemonicToSeedHex(mnemonic: string): string {
   return Buffer.from(seedBytes).toString('hex');
 }
 
-function padSeed(seedHex: string): Uint8Array {
+export function padSeed(seedHex: string): Uint8Array {
   const seed = Buffer.from(seedHex, 'hex');
   if (seed.length !== 16) {
     throw new Error(`Seed must be 16 bytes, got ${seed.length}`);

--- a/run/test/utils/sogs_auth.ts
+++ b/run/test/utils/sogs_auth.ts
@@ -1,0 +1,216 @@
+import { ed25519 } from '@noble/curves/ed25519.js';
+import { blake2b } from '@noble/hashes/blake2.js';
+import { sha512 } from '@noble/hashes/sha2.js';
+import { randomBytes } from 'crypto';
+
+import { mnemonicToSeedHex, padSeed } from './mock_pro';
+
+/**
+ * Authenticated requests to a SOGS (community server) HTTP API.
+ *
+ * SOGS authenticates a request by a signature over its own details, in four `X-SOGS-*` headers, and
+ * a server may require that the signer identify itself by a *blinded* id rather than its real one —
+ * `require_blind_keys`, which is on by default and which the devnet SOGS deliberately leaves on so
+ * it behaves like production. Blinding maps an account to a per-server id, so the same account looks
+ * like an unrelated user on each server it talks to; the server can't reverse it, so it can moderate
+ * a user within a room without learning who they are elsewhere.
+ *
+ * That means signing here is not plain Ed25519 over the account key: the key itself is transformed
+ * first, and the signature has to be produced by hand rather than by `ed25519.sign`. The
+ * implementation below is a transliteration of libsession-util's `blind15_key_pair` /
+ * `blind15_sign` (src/blinding.cpp), which is what the Session clients themselves use — so a request
+ * from here is indistinguishable from a request from a client.
+ */
+
+/** Order of the Ed25519 group; all scalar arithmetic below is mod this. */
+const L = ed25519.Point.Fn.ORDER;
+
+/** An account that can sign SOGS requests: an Ed25519 seed and the public key it derives. */
+export type SogsIdentity = {
+  edPubkey: Uint8Array;
+  seed: Uint8Array;
+};
+
+export type SogsResponse = {
+  /** Parsed JSON, or `{}` for an empty body. */
+  body: unknown;
+  status: number;
+};
+
+export type SogsRequest = {
+  base: string;
+  body?: unknown;
+  identity: SogsIdentity;
+  method: 'DELETE' | 'GET' | 'POST' | 'PUT';
+  /** Request path, including a query string if there is one. */
+  path: string;
+  serverPubkey: Uint8Array;
+  timeoutMs?: number;
+};
+
+// --- byte and scalar helpers ---------------------------------------------------------------------
+//
+// Ed25519 scalars are 32-byte little-endian integers. libsodium exposes arithmetic on them directly
+// (crypto_core_ed25519_scalar_*); noble does not, so they are converted to BigInt and back. The
+// reductions mod L are what libsodium's scalar_reduce/_mul/_add do implicitly.
+
+function scalarFromBytes(bytes: Uint8Array): bigint {
+  let value = 0n;
+  for (let i = bytes.length - 1; i >= 0; i--) {
+    value = (value << 8n) | BigInt(bytes[i]);
+  }
+  return value;
+}
+
+function scalarToBytes(value: bigint): Uint8Array {
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    out[i] = Number((value >> BigInt(8 * i)) & 0xffn);
+  }
+  return out;
+}
+
+function concat(...parts: Array<Uint8Array>): Uint8Array {
+  const out = new Uint8Array(parts.reduce((total, part) => total + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+const utf8 = (value: string) => new Uint8Array(Buffer.from(value, 'utf-8'));
+const base64 = (bytes: Uint8Array) => Buffer.from(bytes).toString('base64');
+const hex = (bytes: Uint8Array) => Buffer.from(bytes).toString('hex');
+
+/**
+ * The x25519 private scalar for an Ed25519 seed — libsodium's
+ * `crypto_sign_ed25519_sk_to_curve25519`: the first half of sha512(seed), clamped.
+ */
+function x25519Scalar(seed: Uint8Array): Uint8Array {
+  const scalar = sha512(seed).slice(0, 32);
+  scalar[0] &= 248;
+  scalar[31] &= 127;
+  scalar[31] |= 64;
+  return scalar;
+}
+
+/**
+ * The blinded keypair this identity presents to the server with this public key: `k` derives from
+ * the server's key alone, so every account blinds consistently for a given server and differently
+ * across servers.
+ */
+function blind15KeyPair(identity: SogsIdentity, serverPubkey: Uint8Array) {
+  const k = scalarFromBytes(blake2b(serverPubkey, { dkLen: 64 })) % L;
+  const a = scalarFromBytes(x25519Scalar(identity.seed));
+  const blindedScalar = (k * a) % L;
+  return {
+    blindedPubkey: ed25519.Point.BASE.multiply(blindedScalar).toBytes(),
+    blindedScalar,
+  };
+}
+
+/**
+ * Sign `message` such that the server verifies it against the blinded public key.
+ *
+ * Hand-rolled rather than `ed25519.sign` because the signing key is a bare scalar (the product of
+ * the account scalar and the blinding factor) with no seed behind it, which is not a shape the
+ * standard API accepts. The result is an ordinary Ed25519 signature over the blinded key, so the
+ * server verifies it with no knowledge that blinding was involved.
+ *
+ * `r` — the per-signature nonce — is derived from the account key and the message, matching what the
+ * clients do. Its derivation is not part of the protocol: any `r` verifies, as long as the same one
+ * is used for both halves. It must never be reused across messages, which deriving it from the
+ * message guarantees.
+ */
+export function blind15Sign(
+  identity: SogsIdentity,
+  serverPubkey: Uint8Array,
+  message: Uint8Array
+): { blindedPubkey: Uint8Array; signature: Uint8Array } {
+  const { blindedPubkey, blindedScalar } = blind15KeyPair(identity, serverPubkey);
+
+  const nonceSeed = sha512(concat(identity.seed, identity.edPubkey)).slice(32);
+  const r = scalarFromBytes(sha512(concat(nonceSeed, blindedPubkey, message))) % L;
+  const sigR = ed25519.Point.BASE.multiply(r).toBytes();
+
+  const hram = scalarFromBytes(sha512(concat(sigR, blindedPubkey, message))) % L;
+  const sigS = (r + ((hram * blindedScalar) % L)) % L;
+
+  return { blindedPubkey, signature: concat(sigR, scalarToBytes(sigS)) };
+}
+
+/** The account behind a 13-word Session recovery phrase (e.g. SOGS_ADMIN_SEED). */
+export function identityFromRecoveryPhrase(recoveryPhrase: string): SogsIdentity {
+  return identityFromSeed(padSeed(mnemonicToSeedHex(recoveryPhrase)));
+}
+
+/** The account behind a raw 32-byte Ed25519 seed. */
+export function identityFromSeed(seed: Uint8Array): SogsIdentity {
+  return { edPubkey: ed25519.getPublicKey(seed), seed };
+}
+
+/** The blinded Session id this identity presents to the server with this public key. */
+export function blindedSessionId(identity: SogsIdentity, serverPubkey: Uint8Array): string {
+  return `15${hex(blind15KeyPair(identity, serverPubkey).blindedPubkey)}`;
+}
+
+/**
+ * Make a signed request, returning the status alongside the body rather than throwing on failure:
+ * callers distinguish outcomes that are not errors (a delete of a room that has already gone) from
+ * ones that are, and a bare status is too little to report either usefully.
+ */
+export async function sogsRequest(request: SogsRequest): Promise<SogsResponse> {
+  const { base, body, identity, method, path, serverPubkey, timeoutMs = 30_000 } = request;
+
+  const nonce = new Uint8Array(randomBytes(16));
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const payload = body === undefined ? undefined : utf8(JSON.stringify(body));
+
+  // Signed over: SERVER_PUBKEY || NONCE || TIMESTAMP || METHOD || PATH [|| '?' || QUERY] || HBODY,
+  // where HBODY is blake2b(body, 64) and is omitted entirely when there is no body. The query string
+  // is included with its `?` only when the request actually has one — a trailing `?` with nothing
+  // after it is not accepted (see handle_http_auth in sogs/routes/auth.py).
+  let signed = concat(serverPubkey, nonce, utf8(timestamp + method + path));
+  if (payload?.length) {
+    signed = concat(signed, blake2b(payload, { dkLen: 64 }));
+  }
+
+  const { blindedPubkey, signature } = blind15Sign(identity, serverPubkey, signed);
+
+  const response = await fetch(`${base}${path}`, {
+    body: payload,
+    headers: {
+      'X-SOGS-Nonce': base64(nonce),
+      'X-SOGS-Pubkey': `15${hex(blindedPubkey)}`,
+      'X-SOGS-Signature': base64(signature),
+      'X-SOGS-Timestamp': timestamp,
+      ...(payload ? { 'Content-Type': 'application/json' } : {}),
+    },
+    method,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  const text = await response.text();
+  let parsed: unknown = {};
+  if (text !== '') {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      // SOGS answers its own errors as plain text, and anything else on the port (a proxy, the wrong
+      // service) will not be JSON either. Keep the body so the caller can report it.
+      parsed = text;
+    }
+  }
+
+  return { body: parsed, status: response.status };
+}
+
+/** Describe a failed response for an error message, preferring SOGS's own explanation. */
+export function describeFailure(response: SogsResponse): string {
+  if (typeof response.body === 'string' && response.body !== '') {
+    return `HTTP ${response.status}: ${response.body.trim().split('\n')[0]}`;
+  }
+  return `HTTP ${response.status}`;
+}

--- a/run/test/utils/sogs_seed_message.ts
+++ b/run/test/utils/sogs_seed_message.ts
@@ -1,0 +1,120 @@
+import { blake2b } from '@noble/hashes/blake2.js';
+
+import { blind15Sign, identityFromSeed, SogsIdentity } from './sogs_auth';
+
+/**
+ * The first message in a freshly created community room.
+ *
+ * A room with no messages in it is not a state the clients handle: `joinCommunity` waits for a
+ * message body to appear before it considers the room open, and an empty room never produces one, so
+ * the join *hangs* rather than failing. Creating a room therefore includes posting to it — see
+ * `allocateCommunityRooms`.
+ *
+ * Which means the message has to be one a client will render, i.e. a real Session message: a
+ * protobuf `Content` carrying a `DataMessage`. The three field numbers used below come from
+ * SessionProtos.proto (`Content.dataMessage = 1`; `DataMessage.body = 1`, `.timestamp = 7`,
+ * `.profile = 101`; `LokiProfile.displayName = 1`) and are encoded by hand: pulling in a protobuf
+ * runtime and a copy of the schema to keep in sync would be a lot of machinery for one fixed
+ * message whose shape never varies.
+ */
+
+const SEED_DISPLAY_NAME = 'Room Seeder';
+
+// --- protobuf wire format ------------------------------------------------------------------------
+
+const VARINT = 0;
+const LENGTH_DELIMITED = 2;
+
+function varint(value: bigint | number): Uint8Array {
+  let remaining = BigInt(value);
+  const bytes: Array<number> = [];
+  do {
+    const septet = Number(remaining & 0x7fn);
+    remaining >>= 7n;
+    bytes.push(remaining > 0n ? septet | 0x80 : septet);
+  } while (remaining > 0n);
+  return new Uint8Array(bytes);
+}
+
+function tag(field: number, wireType: number): Uint8Array {
+  return varint((field << 3) | wireType);
+}
+
+function concat(parts: Array<Uint8Array>): Uint8Array {
+  const out = new Uint8Array(parts.reduce((total, part) => total + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+/** A `bytes`/`string`/embedded-message field: tag, then length, then the payload. */
+function delimitedField(field: number, payload: Uint8Array): Uint8Array {
+  return concat([tag(field, LENGTH_DELIMITED), varint(payload.length), payload]);
+}
+
+function stringField(field: number, value: string): Uint8Array {
+  return delimitedField(field, new Uint8Array(Buffer.from(value, 'utf-8')));
+}
+
+function varintField(field: number, value: bigint | number): Uint8Array {
+  return concat([tag(field, VARINT), varint(value)]);
+}
+
+// --- the message ---------------------------------------------------------------------------------
+
+/**
+ * Sender for a room's seed message: derived from the room token, so it is stable for a given room and
+ * distinct between rooms, and belongs to no real account.
+ *
+ * Deliberately not the admin identity that creates the room. SOGS takes a user's display name from
+ * the messages they post, so seeding as the admin would rename the admin account to the seeder's
+ * name in every room — visible to the community moderation tests, which restore that same account.
+ */
+export function seedIdentityForRoom(token: string): SogsIdentity {
+  return identityFromSeed(
+    blake2b(new Uint8Array(Buffer.from(token, 'utf-8')), {
+      dkLen: 32,
+      personalization: new Uint8Array(Buffer.from('sogsseed'.padEnd(16, '\0'), 'utf-8')),
+    })
+  );
+}
+
+/**
+ * The body of a `POST /room/<token>/message` request that seeds `roomName`.
+ *
+ * `data` is padded before signing and sent padded: Session appends `0x80` followed by zero bytes to
+ * hide a message's true length, the signature covers the padded bytes, and SOGS records the padded
+ * length so it can hand a client back exactly what was signed. The minimum such padding is the
+ * `0x80` and one zero byte.
+ *
+ * The signature is by the *blinded* key, not the account key, because that is the key a reader checks
+ * it against: SOGS records the poster as the blinded id the request authenticated with, and a client
+ * verifies a message against the key in its sender's id. Signing with the account key would produce
+ * a message every client discards — which, since the room then still looks empty, would hang the join
+ * exactly as an unseeded room does.
+ */
+export function buildSeedMessage(token: string, roomName: string, serverPubkey: Uint8Array) {
+  const content = delimitedField(
+    1, // Content.dataMessage
+    concat([
+      stringField(1, `Welcome to ${roomName}!`), // DataMessage.body
+      varintField(7, Date.now()), // DataMessage.timestamp (ms)
+      delimitedField(101, stringField(1, SEED_DISPLAY_NAME)), // DataMessage.profile.displayName
+    ])
+  );
+
+  const padded = concat([content, new Uint8Array([0x80, 0x00])]);
+  const identity = seedIdentityForRoom(token);
+  const { signature } = blind15Sign(identity, serverPubkey, padded);
+
+  return {
+    identity,
+    request: {
+      data: Buffer.from(padded).toString('base64'),
+      signature: Buffer.from(signature).toString('base64'),
+    },
+  };
+}

--- a/run/types/sessionIt.ts
+++ b/run/types/sessionIt.ts
@@ -4,6 +4,11 @@ import { omit } from 'lodash';
 import type { AppCountPerTest } from '../test/state_builder';
 
 import { setupAllureTestInfo } from '../test/utils/allure/allureHelpers';
+import {
+  allocateCommunityRooms,
+  perTestRoomsEnabled,
+  releaseCommunityRooms,
+} from '../test/utils/community_rooms';
 import { unregisterDevicesForTest } from '../test/utils/device_registry';
 import { getNetworkTarget } from '../test/utils/devnet';
 import { captureLogsOnFailure, captureScreenshotsOnFailure } from '../test/utils/failure_artifacts';
@@ -20,6 +25,12 @@ type MobileItArgs = {
   testCb: (platform: SupportedPlatformsType, testInfo: TestInfo) => Promise<void>;
   shouldSkip?: boolean;
   isPro?: boolean;
+  /**
+   * How many community rooms this test needs. Against a local SOGS the rooms are created for this
+   * test alone and deleted afterwards, so the test can leave them in any state it likes. Reading
+   * `communities` without declaring this throws — see constants/community.ts.
+   */
+  communityRooms?: number;
   allureSuites?: AllureSuiteConfig;
   allureDescription?: string;
   allureLinks?: {
@@ -45,6 +56,7 @@ function mobileIt({
   shouldSkip = false,
   isPro = false,
   countOfDevicesNeeded,
+  communityRooms,
   allureSuites,
   allureDescription,
   allureLinks,
@@ -73,6 +85,18 @@ function mobileIt({
     });
 
     let testFailed = false;
+
+    if (communityRooms && perTestRoomsEnabled()) {
+      try {
+        await allocateCommunityRooms(communityRooms);
+      } catch (allocationError) {
+        // Allocation sits outside the try below, so its `finally` — where rooms are released — is not
+        // reached if allocation itself fails. A partly-completed allocation has still created rooms,
+        // so release them here rather than leaving them for the gc TTL.
+        await releaseCommunityRooms();
+        throw allocationError;
+      }
+    }
 
     try {
       await testCb(platform, testInfo);
@@ -115,6 +139,14 @@ function mobileIt({
         unregisterDevicesForTest(testInfo);
       } catch (cleanupError) {
         console.error('Failed to unregister devices:', cleanupError);
+      }
+
+      // Anything missed here (timeouts and interrupts skip this block, per the note above) is
+      // collected by the gc sweep in global-setup.
+      try {
+        await releaseCommunityRooms();
+      } catch (cleanupError) {
+        console.error('Failed to release community rooms:', cleanupError);
       }
     }
   });


### PR DESCRIPTION
The community specs shared a fixed set of rooms, so two runs against the same SOGS - CI and a laptop, or two CI jobs - joined, posted, pinned and banned in the same place, and a test had to leave its rooms usable for the next one.

A spec now declares `communityRooms: <n>` and is given rooms created for it alone, deleted in its teardown. Room tokens carry a per-run id so concurrent runs cannot delete each other's rooms, only `qa-`-prefixed rooms are ever removed, and a gc sweep at the start of each run collects what an interrupted run left behind.

`communities` resolves per test rather than at module load. Reading it without declaring `communityRooms` throws: returning a shared room silently is the behaviour this replaces, and it would fail somewhere unrelated to the cause.

Rooms are managed through Sesh-Net-Docker's `sogs/room.sh`, or over HTTP when SOGS_ROOM_API and SOGS_ROOM_API_TOKEN are set - for hosts that can reach the SOGS container but cannot `docker exec` into it. PySOGS has no room-creation endpoint, so one of the two is required.

Whether rooms can be created is settled once at startup. If neither transport works the run falls back to the shared rooms with a warning rather than failing, since that configuration still exercises everything - it just cannot isolate concurrent runs. Without COMMUNITY_LINK the suite uses the remote communities exactly as before, so this is inert anywhere a local SOGS isn't configured.