### PR TITLE
Fixed three flaky failure modes in the mobile specs

### DIFF
--- a/run/test/specs/mobile/community_ban.spec.ts
+++ b/run/test/specs/mobile/community_ban.spec.ts
@@ -14,8 +14,7 @@ import {
   OutgoingMessageStatusSent,
   SendButton,
 } from '../../locators/conversation';
-import { ConversationItem } from '../../locators/home';
-import { assertAdminIsKnown, joinCommunity } from '../../utils/community';
+import { assertAdminIsKnown, joinCommunity, openOrJoinCommunity } from '../../utils/community';
 import { newUser } from '../../utils/create_account';
 import { closeApp, openAppTwoDevices, SupportedPlatformsType } from '../../utils/open_app';
 import { restoreAccount } from '../../utils/restore_account';
@@ -67,15 +66,11 @@ async function banUserCommunity(platform: SupportedPlatformsType, testInfo: Test
       ]);
     });
   await test.step(TestSteps.NEW_CONVERSATION.JOIN_COMMUNITY, async () => {
-    const adminJoined = await alice1.doesElementExist(
-      new ConversationItem(alice1, communities.testCommunity.name)
+    await openOrJoinCommunity(
+      alice1,
+      communities.testCommunity.link,
+      communities.testCommunity.name
     );
-    if (!adminJoined) {
-      await joinCommunity(alice1, communities.testCommunity.link, communities.testCommunity.name);
-    } else {
-      await alice1.clickOnElementAll(new ConversationItem(alice1, communities.testCommunity.name));
-      await alice1.scrollToBottom();
-    }
     await joinCommunity(bob1, communities.testCommunity.link, communities.testCommunity.name);
   });
   await test.step(TestSteps.SEND.MESSAGE('Bob', 'community'), async () => {
@@ -137,15 +132,11 @@ async function banAndDelete(platform: SupportedPlatformsType, testInfo: TestInfo
     ]);
   });
   await test.step(TestSteps.NEW_CONVERSATION.JOIN_COMMUNITY, async () => {
-    const adminJoined = await alice1.doesElementExist(
-      new ConversationItem(alice1, communities.testCommunity.name)
+    await openOrJoinCommunity(
+      alice1,
+      communities.testCommunity.link,
+      communities.testCommunity.name
     );
-    if (!adminJoined) {
-      await joinCommunity(alice1, communities.testCommunity.link, communities.testCommunity.name);
-    } else {
-      await alice1.clickOnElementAll(new ConversationItem(alice1, communities.testCommunity.name));
-      await alice1.scrollToBottom();
-    }
     await joinCommunity(bob1, communities.testCommunity.link, communities.testCommunity.name);
   });
   await test.step(TestSteps.SEND.MESSAGE('Bob', 'community'), async () => {

--- a/run/test/specs/mobile/cta_donate_time.spec.ts
+++ b/run/test/specs/mobile/cta_donate_time.spec.ts
@@ -56,12 +56,17 @@ iosIt({
     parent: 'Donations',
   },
   allureDescription:
-    'Mocks a custom install date 6 days, 23 hours, and 58 minutes ago, opens the app, and verifies that the Donate CTA does not show.',
+    'Mocks a custom install date 6 days and 23 hours ago, opens the app, and verifies that the Donate CTA does not show.',
 });
 
 async function donateCTADoesntShowSixDaysAgo(platform: SupportedPlatformsType, testInfo: TestInfo) {
+  // The install date is mocked as an absolute timestamp but the app re-evaluates it live
+  // (DonationsManager.conversationListDidAppear compares it against `now` every time the
+  // conversation list appears), so the gap below has to outlast the whole test — onboarding
+  // included — or the account ages past 7 days mid-run and the CTA legitimately appears.
+  // Anything under 7 days exercises the same branch, so the margin costs no coverage.
   const iosContext: IOSTestContext = {
-    customInstallTime: setIOSFirstInstallDate({ days: -6, hours: -23, minutes: -58 }),
+    customInstallTime: setIOSFirstInstallDate({ days: -6, hours: -23 }),
   };
   const { device } = await test.step(TestSteps.SETUP.NEW_USER, async () => {
     const { device } = await openAppOnPlatformSingleDevice(platform, testInfo, iosContext);

--- a/run/test/specs/mobile/linked_device_community_ban.spec.ts
+++ b/run/test/specs/mobile/linked_device_community_ban.spec.ts
@@ -16,7 +16,7 @@ import {
   SendButton,
 } from '../../locators/conversation';
 import { ConversationItem } from '../../locators/home';
-import { assertAdminIsKnown, joinCommunity } from '../../utils/community';
+import { assertAdminIsKnown, joinCommunity, openOrJoinCommunity } from '../../utils/community';
 import { newUser } from '../../utils/create_account';
 import { closeApp, openAppThreeDevices, SupportedPlatformsType } from '../../utils/open_app';
 import { restoreAccount } from '../../utils/restore_account';
@@ -73,15 +73,11 @@ async function banUnbanLinked(platform: SupportedPlatformsType, testInfo: TestIn
       return await Promise.all([restoreAccount(alice1, alice, 'alice1'), newUser(bob1, 'Bob')]);
     });
   await test.step(TestSteps.NEW_CONVERSATION.JOIN_COMMUNITY, async () => {
-    const adminJoined = await alice1.doesElementExist(
-      new ConversationItem(alice1, communities.testCommunity.name)
+    await openOrJoinCommunity(
+      alice1,
+      communities.testCommunity.link,
+      communities.testCommunity.name
     );
-    if (!adminJoined) {
-      await joinCommunity(alice1, communities.testCommunity.link, communities.testCommunity.name);
-    } else {
-      await alice1.clickOnElementAll(new ConversationItem(alice1, communities.testCommunity.name));
-      await alice1.scrollToBottom();
-    }
     await joinCommunity(bob1, communities.testCommunity.link, communities.testCommunity.name);
   });
   await test.step(TestSteps.SEND.MESSAGE('Bob', 'community'), async () => {
@@ -103,7 +99,7 @@ async function banUnbanLinked(platform: SupportedPlatformsType, testInfo: TestIn
   });
   await test.step(TestSteps.SETUP.RESTORE_ACCOUNT('Bob'), async () => {
     await restoreAccount(bob2, bob, 'bob2');
-    await bob2.clickOnElementAll(new ConversationItem(alice1, communities.testCommunity.roomName)); // Since we're banned we don't get the "real" name
+    await bob2.clickOnElementAll(new ConversationItem(bob2, communities.testCommunity.roomName)); // Since we're banned we don't get the "real" name
     await bob2.waitForTextElementToBePresent(new EmptyConversation(bob2));
     await bob2.onIOS().waitForTextElementToBePresent({
       strategy: 'xpath',
@@ -147,15 +143,11 @@ async function banAndDeleteLinked(platform: SupportedPlatformsType, testInfo: Te
       return await Promise.all([restoreAccount(alice1, alice, 'alice1'), newUser(bob1, 'Bob')]);
     });
   await test.step(TestSteps.NEW_CONVERSATION.JOIN_COMMUNITY, async () => {
-    const adminJoined = await alice1.doesElementExist(
-      new ConversationItem(alice1, communities.testCommunity.name)
+    await openOrJoinCommunity(
+      alice1,
+      communities.testCommunity.link,
+      communities.testCommunity.name
     );
-    if (!adminJoined) {
-      await joinCommunity(alice1, communities.testCommunity.link, communities.testCommunity.name);
-    } else {
-      await alice1.clickOnElementAll(new ConversationItem(alice1, communities.testCommunity.name));
-      await alice1.scrollToBottom();
-    }
     await joinCommunity(bob1, communities.testCommunity.link, communities.testCommunity.name);
   });
   await test.step(TestSteps.SEND.MESSAGE('Bob', 'community'), async () => {
@@ -174,7 +166,7 @@ async function banAndDeleteLinked(platform: SupportedPlatformsType, testInfo: Te
   });
   await test.step(TestSteps.SETUP.RESTORE_ACCOUNT('Bob'), async () => {
     await restoreAccount(bob2, bob, 'bob2');
-    await bob2.clickOnElementAll(new ConversationItem(alice1, communities.testCommunity.roomName)); // Since we're banned we don't get the "real" name
+    await bob2.clickOnElementAll(new ConversationItem(bob2, communities.testCommunity.roomName)); // Since we're banned we don't get the "real" name
     await bob2.waitForTextElementToBePresent(new EmptyConversation(bob2));
   });
   await test.step('Verify Bob cannot send messages in community on either device', async () => {

--- a/run/test/utils/community.ts
+++ b/run/test/utils/community.ts
@@ -4,7 +4,7 @@ import { communities } from '../../constants/community';
 import { DeviceWrapper } from '../../types/DeviceWrapper';
 import { CommunityInput, JoinCommunityButton } from '../locators';
 import { ConversationHeaderName, MessageBody } from '../locators/conversation';
-import { PlusButton } from '../locators/home';
+import { ConversationItem, PlusButton } from '../locators/home';
 import { JoinCommunityOption } from '../locators/start_conversation';
 
 export function assertAdminIsKnown() {
@@ -26,6 +26,30 @@ export const joinCommunity = async (
   await device.clickOnElementAll(new JoinCommunityButton(device));
   await device.waitForTextElementToBePresent(new ConversationHeaderName(device, communityName));
   await device.waitForTextElementToBePresent(new MessageBody(device)); // Check for ANY message
+  await device.scrollToBottom();
+};
+
+/**
+ * Leave `device` inside the community's conversation, joining it first if it isn't there already.
+ *
+ * Accounts restored from a seed (the SOGS admin) may or may not have the community yet, depending
+ * on what their config sync has restored, so both outcomes are expected. Both paths assert the
+ * conversation actually opened before returning: an iOS tap that silently doesn't register would
+ * otherwise leave the caller on the home screen and surface several steps later as a missing
+ * message, which points at entirely the wrong thing.
+ */
+export const openOrJoinCommunity = async (
+  device: DeviceWrapper,
+  communityLink: string,
+  communityName: string
+) => {
+  const alreadyJoined = await device.doesElementExist(new ConversationItem(device, communityName));
+  if (!alreadyJoined) {
+    await joinCommunity(device, communityLink, communityName);
+    return;
+  }
+  await device.clickOnElementAll(new ConversationItem(device, communityName));
+  await device.waitForTextElementToBePresent(new ConversationHeaderName(device, communityName));
   await device.scrollToBottom();
 };
 

--- a/run/types/DeviceWrapper.ts
+++ b/run/types/DeviceWrapper.ts
@@ -2522,12 +2522,23 @@ export class DeviceWrapper implements IMobileWrapper {
     // if the button applies it's already in the tree — a short probe is enough. `maxWait` only
     // bounds the ABSENT case (a present button returns as soon as it's found), so keeping this low
     // avoids burning the full wait every time the view opens already at the bottom.
-    if (
-      await this.doesElementExist({ ...new ScrollToBottomButton(this).build(), maxWait: 1_000 })
-    ) {
-      await this.clickOnElementAll(new ScrollToBottomButton(this));
-    } else {
+    const button = await this.doesElementExist({
+      ...new ScrollToBottomButton(this).build(),
+      maxWait: 1_000,
+    });
+    if (!button) {
       this.info('Scroll button not found, continuing');
+      return;
+    }
+    // Tap the handle the probe returned rather than looking it up again: the button removes itself
+    // as soon as the list reaches the bottom (an incoming message auto-scrolling is enough), and a
+    // second lookup would wait the default 60s and then throw — turning a best-effort helper into a
+    // test failure.
+    try {
+      await this.click(button.ELEMENT);
+    } catch {
+      // Losing it between the probe and the tap means we're already where we wanted to be.
+      this.info('Scroll button disappeared before it could be tapped, continuing');
     }
   }
   public async pullToRefresh(): Promise<void> {


### PR DESCRIPTION
The Donate CTA negative test mocked an install date two minutes short of the seven-day threshold. The app re-evaluates that date against the current time whenever the conversation list appears, so any run slower than two minutes aged past the threshold and the CTA legitimately appeared. Widened to one hour.

scrollToBottom probed for the button with a 1s wait and then looked it up again with the default 60s one. The button removes itself once the list reaches the bottom, so losing it between the two calls turned a best-effort helper into a 60s wait followed by a hard failure. It now taps the handle the probe returned.

The community ban specs clicked the conversation row without confirming it opened, leaving an unregistered tap to surface several steps later as a missing message. Both branches now go through openOrJoinCommunity, which asserts the conversation is open before returning.

Two locators in linked_device_community_ban were built against alice1 but used on bob2.